### PR TITLE
🧐 Lets PR workflow work smarter not harder

### DIFF
--- a/.github/workflows/merge-request.yml
+++ b/.github/workflows/merge-request.yml
@@ -9,41 +9,63 @@ jobs:
       run:
         working-directory: ./lib
     steps:
+      - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
           node-version: "16"
-      - uses: actions/checkout@v2
+          cache: 'npm'
+          cache-dependency-path: './lib/package-lock.json'
       - run: npm ci
       - run: npm test
       - run: npm run lint
+      - run: npm pack
+      - uses: actions/upload-artifact@v2
+        with:
+          name: opentdf-client-lib
+          path: ./lib/opentdf-client-*.tgz
+          retention-days: 1
 
   cli:
+    needs:
+      - lib
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./cli
     steps:
+      - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
           node-version: "16"
-      - uses: actions/checkout@v2
-      - run: make ci
-        working-directory: ./
+          cache: 'npm'
+          cache-dependency-path: './cli/package-lock.json'
+      - uses: actions/download-artifact@v2
+        with:
+          name: opentdf-client-lib
+      - run: npm uninstall @opentdf/client && npm ci && npm i ../opentdf-client-*.tgz
       - run: npm test
       - run: npm run lint
+      - run: npm pack
 
   sample-web-app:
+    needs:
+      - lib
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./sample-web-app
     steps:
+      - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
           node-version: "16"
-      - uses: actions/checkout@v2
-      - run: make ci
-        working-directory: ./
+          cache: 'npm'
+          cache-dependency-path: './sample-web-app/package-lock.json'
+      - uses: actions/download-artifact@v2
+        with:
+          name: opentdf-client-lib
+      - run: npm uninstall @opentdf/client && npm ci && npm i ../opentdf-client-*.tgz
       - run: npm install
       - run: npm test
       - run: npm run lint
+      - run: npm pack


### PR DESCRIPTION
- Only run child builds after lib builds succeed
- Cache stuff!
- Use the generated tgz from the lib build in the child builds
- Run `npm pack` so we validate that the libraries pack (i.e. run `build`)