### PR TITLE
No_REf : updated target to ES2017

### DIFF
--- a/lib/tsconfig.json
+++ b/lib/tsconfig.json
@@ -23,7 +23,7 @@
     "strictFunctionTypes": true,
     "strictNullChecks": true,
     "strictPropertyInitialization": true,
-    "target": "es2020"
+    "target": "es2017"
   },
   "include": ["src", "test"]
 }


### PR DESCRIPTION
TypeScript target `es2017` for support of create-react-app

Signed-off-by: obidenko <obidenko@virtru.com>