### PR TITLE
fix: Remove environment logging in vite.config.ts

### DIFF
--- a/web-app/vite.config.ts
+++ b/web-app/vite.config.ts
@@ -5,7 +5,6 @@ import react from '@vitejs/plugin-react';
 const require = createRequire(import.meta.url)
 
 function proxy(): Record<string, string> {
-  console.log(process.env);
   const { VITE_PROXY } = process.env;
   if (VITE_PROXY) {
     console.log(`using VITE_PROXY [${VITE_PROXY}]`);


### PR DESCRIPTION
The environment may contain sensitive secrets.  For this reason we should avoid logging it to the console.  This was identified by CodeQL here: https://github.com/opentdf/web-sdk/security/code-scanning/3