### PR TITLE
fix: Changes to make regex patterns more efficient, accurate and simpler

### DIFF
--- a/lib/tdf3/src/client/validation.ts
+++ b/lib/tdf3/src/client/validation.ts
@@ -12,10 +12,10 @@ const SCHEME = '(https?://)';
 const HOST_PORT = '([a-z0-9][a-z0-9]{1,}:[0-9]{1,4})';
 
 // validate url host be like `www.example.com`
-const WWW_HOST = '((?:www.|(?!www))([a-z0-9][a-z0-9-]*[a-z0-9].)+[^s]{2,})';
+const WWW_HOST = '((?:www\\.|(?!www\\.))([a-z0-9][a-z0-9-]*[a-z0-9]\\.)+[a-z]{2,})';
 
 // validate url host be like `127.0.0.1:4000`
-const IP_HOST_PORT = '([0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}:[0-9]{1,4})';
+const IP_HOST_PORT = '([0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}:[0-9]{1,4})';
 
 // validate host is one of those above
 const HOST = `(${HOST_PORT}|${WWW_HOST}|${IP_HOST_PORT})`;

--- a/lib/tdf3/src/client/validation.ts
+++ b/lib/tdf3/src/client/validation.ts
@@ -12,7 +12,7 @@ const SCHEME = '(https?://)';
 const HOST_PORT = '([a-z0-9][a-z0-9]{1,}:[0-9]{1,4})';
 
 // validate url host be like `www.example.com`
-const WWW_HOST = '((?:www\\.)?(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\\.)+[a-z]{2,})';
+const WWW_HOST = '([a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+[a-z]{2,}';
 
 // validate url host be like `127.0.0.1:4000`
 const IP_HOST_PORT = '([0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}:[0-9]{1,4})';

--- a/lib/tdf3/src/client/validation.ts
+++ b/lib/tdf3/src/client/validation.ts
@@ -12,7 +12,7 @@ const SCHEME = '(https?://)';
 const HOST_PORT = '([a-z0-9][a-z0-9]{1,}:[0-9]{1,4})';
 
 // validate url host be like `www.example.com`
-const WWW_HOST = '((?:www\\.|(?!www\\.))([a-z0-9][a-z0-9-]*[a-z0-9]\\.)+[a-z]{2,})';
+const WWW_HOST = '((?:www\\.)?(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\\.)+[a-z]{2,})';
 
 // validate url host be like `127.0.0.1:4000`
 const IP_HOST_PORT = '([0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}:[0-9]{1,4})';

--- a/lib/tdf3/src/tdf.ts
+++ b/lib/tdf3/src/tdf.ts
@@ -325,7 +325,7 @@ export function unwrapHtml(htmlPayload: ArrayBuffer | Uint8Array | Binary | stri
   } else {
     html = htmlPayload.toString();
   }
-  const payloadRe = /<input id=['"]?data-input['"]?[^>]*value=['"]?([a-zA-Z0-9+/=]+)['"]?/;
+  const payloadRe = /<input id=['"]?data-input['"]?[^>]*?value=['"]?([a-zA-Z0-9+/=]+)['"]?/;
   const reResult = payloadRe.exec(html);
   if (reResult === null) {
     throw new InvalidFileError('Payload is missing');


### PR DESCRIPTION
This PR contains changes to address regex issues discovered by CodeQL:
* https://github.com/opentdf/web-sdk/security/code-scanning/8
* https://github.com/opentdf/web-sdk/security/code-scanning/9

Changes (see also commit messages):
* First commit contains two changes.  First to ensure that `.` characters in the url and ip addresses match only the literal `.` vs interpreted as "any character".  This is both a fix to make the patterns more precise, as well as more efficent.
* The first commit also fixes the WWW_HOST TLD part of the pattern.  Specifically `^s` was switched to `a-z`.  `^s` will match any character except `s`, it is assumed that `^\s` was expected (to match any non-whitespace character).  However the `a-z` check is simpler and more precise.
* The second commit addresses potential backtrack inefficiency by replacing `[^>]*` with `[^>]*?`.  The additional `?` will result in a non-greedy match (resulting in as minimal backtracking as possible to find a match).

After discussing with @dmihalcik-virtru we decided to further simplify `WWW_HOST` pattern.  We are able to remove the `www` and negative `www` check, remove the group capturing, and simplify the subdomain pattern.  Overall this notably improves the performance and understanding of this pattern.