### PR TITLE
fix: set defatult mimeType in tdf manifest

### DIFF
--- a/lib/tdf3/src/tdf.ts
+++ b/lib/tdf3/src/tdf.ts
@@ -68,6 +68,7 @@ import { SymmetricCipher } from './ciphers/symmetric-cipher-base.js';
 
 // TODO: input validation on manifest JSON
 const DEFAULT_SEGMENT_SIZE = 1024 * 1024;
+const DEFAULT_MIME_TYPE = 'application/octet-stream';
 
 /**
  * Configuration for TDF3
@@ -445,7 +446,7 @@ async function _generateManifest(
     protocol: 'zip',
     isEncrypted: true,
     schemaVersion: '3.0.0',
-    ...(mimeType && { mimeType }),
+    mimeType: mimeType || DEFAULT_MIME_TYPE,
   };
 
   const encryptionInformationStr = await encryptionInformation.write(policy, keyInfo);


### PR DESCRIPTION
The spec says mimeType is optional but goes on to say there is a default of `application/octet-stream`. This is one of the reasons json schema validation is failing. 