### PR TITLE
chore: Remove 'make test' step from deploy workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -217,7 +217,6 @@ jobs:
         run: |-
           echo "FULL_VERSION=$(.github/workflows/gh-semver.sh)" >> $GITHUB_OUTPUT
           echo "DIST_TAG=$(.github/workflows/guess-dist-tag.sh)" >> $GITHUB_OUTPUT
-      - run: make test
       - run: make doc
       - run: >-
           echo "::notice file=lib/package.json::Will be published to


### PR DESCRIPTION
The 'make test' step has been removed from the GitHub Actions build workflow. This change simplifies the workflow by focusing on documentation generation and publication preparation. Any testing should be configured separately or integrated into other steps if necessary.