### PR TITLE
chore: documentation generation to include npm ci

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,4 +44,4 @@ format license-check lint test: ci
 	for x in $(pkgs); do (cd $$x && npm run $@) || exit 1; done
 
 doc:
-	cd lib && npm run doc
+	cd lib && npm ci && npm run doc


### PR DESCRIPTION
The Makefile now ensures dependencies are installed before generating documentation. This change avoids potential issues with missing or outdated packages during the documentation process.