### PR TITLE
feat!(sdk): Remove 'toFile' method

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -360,17 +360,15 @@
     "node_modules/@opentdf/sdk": {
       "version": "0.2.0",
       "resolved": "file:../lib/opentdf-sdk-0.2.0.tgz",
-      "integrity": "sha512-l6lK7So2oS9+j9W+59H3S36G64v2W/Un1iw6RDFhHfRmK21fM/bTnJC7apAjEQjO/mv8phNd1li0U9ninPgkAw==",
+      "integrity": "sha512-7hXtbo8HTy8eV7QZd+8aRLbUR8mEKSU+Zc5MKTCGIhGMc8uIRKMuTFoeCCRsUJUXH3RiNoujFoaZMSyc1ffbow==",
       "license": "BSD-3-Clause-Clear",
       "dependencies": {
         "base64-js": "^1.5.1",
         "browser-fs-access": "^0.34.1",
         "buffer-crc32": "^0.2.13",
         "dpop": "^1.2.0",
-        "eventemitter3": "^5.0.1",
         "jose": "^4.14.4",
         "json-canonicalize": "^1.0.6",
-        "streamsaver": "^2.0.6",
         "uuid": "~9.0.0"
       }
     },
@@ -1405,12 +1403,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/eventemitter3": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
-      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -2866,18 +2858,6 @@
         "spdx-expression-parse": "^3.0.0",
         "spdx-ranges": "^2.0.0"
       }
-    },
-    "node_modules/streamsaver": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/streamsaver/-/streamsaver-2.0.6.tgz",
-      "integrity": "sha512-LK4e7TfCV8HzuM0PKXuVUfKyCB1FtT9L0EGxsFk5Up8njj0bXK8pJM9+Wq2Nya7/jslmCQwRK39LFm55h7NBTw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "4.2.3",

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -360,10 +360,9 @@
     "node_modules/@opentdf/sdk": {
       "version": "0.2.0",
       "resolved": "file:../lib/opentdf-sdk-0.2.0.tgz",
-      "integrity": "sha512-7hXtbo8HTy8eV7QZd+8aRLbUR8mEKSU+Zc5MKTCGIhGMc8uIRKMuTFoeCCRsUJUXH3RiNoujFoaZMSyc1ffbow==",
+      "integrity": "sha512-Ic6Tl6tV/TI9JPyjAnfywPen0t78JSkiupDKdpSVa2ZW8B69yU0oh65aC8oxniZJ57krRIFn/HxY1lX0HTk+TQ==",
       "license": "BSD-3-Clause-Clear",
       "dependencies": {
-        "base64-js": "^1.5.1",
         "browser-fs-access": "^0.34.1",
         "buffer-crc32": "^0.2.13",
         "dpop": "^1.2.0",
@@ -874,26 +873,6 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
-    },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",

--- a/lib/package-lock.json
+++ b/lib/package-lock.json
@@ -12,10 +12,8 @@
         "browser-fs-access": "^0.34.1",
         "buffer-crc32": "^0.2.13",
         "dpop": "^1.2.0",
-        "eventemitter3": "^5.0.1",
         "jose": "^4.14.4",
         "json-canonicalize": "^1.0.6",
-        "streamsaver": "^2.0.6",
         "uuid": "~9.0.0"
       },
       "devDependencies": {
@@ -4891,10 +4889,6 @@
         "through": "^2.3.8"
       }
     },
-    "node_modules/eventemitter3": {
-      "version": "5.0.1",
-      "license": "MIT"
-    },
     "node_modules/events": {
       "version": "3.3.0",
       "dev": true,
@@ -9727,16 +9721,6 @@
       "engines": {
         "node": ">=8.0"
       }
-    },
-    "node_modules/streamsaver": {
-      "version": "2.0.6",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/streamx": {
       "version": "2.20.1",

--- a/lib/package.json
+++ b/lib/package.json
@@ -70,10 +70,8 @@
     "browser-fs-access": "^0.34.1",
     "buffer-crc32": "^0.2.13",
     "dpop": "^1.2.0",
-    "eventemitter3": "^5.0.1",
     "jose": "^4.14.4",
     "json-canonicalize": "^1.0.6",
-    "streamsaver": "^2.0.6",
     "uuid": "~9.0.0"
   },
   "devDependencies": {

--- a/lib/tdf3/src/client/DecoratedReadableStream.ts
+++ b/lib/tdf3/src/client/DecoratedReadableStream.ts
@@ -1,11 +1,5 @@
-import { EventEmitter } from 'eventemitter3';
-import streamSaver from 'streamsaver';
-import { fileSave } from 'browser-fs-access';
-import { isFirefox } from '../../../src/utils.js';
-
 import { type Metadata } from '../tdf.js';
 import { type Manifest } from '../models/index.js';
-import { ConfigurationError } from '../../../src/errors.js';
 
 export async function streamToBuffer(stream: ReadableStream<Uint8Array>): Promise<Uint8Array> {
   const accumulator = await new Response(stream).arrayBuffer();
@@ -24,9 +18,6 @@ export class DecoratedReadableStream {
   tdfSize: number;
   fileSize: number | undefined;
   stream: ReadableStream<Uint8Array>;
-  ee: EventEmitter;
-  on: EventEmitter['on'];
-  emit: EventEmitter['emit'];
   metadata?: Metadata;
   manifest: Manifest;
   fileStreamServiceWorker?: string;
@@ -42,23 +33,10 @@ export class DecoratedReadableStream {
     this.stream = new ReadableStream(underlyingSource, {
       highWaterMark: 1,
     }) as ReadableStream<Uint8Array>;
-    this.ee = new EventEmitter();
-    this.on = (...args) => this.ee.on(...args);
-    this.emit = (...args) => this.ee.emit(...args);
   }
 
   async getMetadata() {
-    return new Promise((resolve, reject) => {
-      if (this.metadata) {
-        resolve(this.metadata);
-      } else {
-        this.on('error', reject);
-        this.on('rewrap', (rewrapResponse: Metadata) => {
-          this.metadata = rewrapResponse;
-          resolve(rewrapResponse);
-        });
-      }
-    });
+    return this.metadata;
   }
 
   /**
@@ -82,66 +60,12 @@ export class DecoratedReadableStream {
   async toString(): Promise<string> {
     return new Response(this.stream).text();
   }
-
-  /**
-   * Dump the stream content to a local file. This will consume the stream.
-   *
-   * @param filepath The path of the local file to write plaintext to.
-   * @param encoding The charset encoding to use. Defaults to utf-8.
-   */
-  async toFile(
-    filepath = 'download.tdf',
-    options?: BufferEncoding | DecoratedReadableStreamSinkOptions
-  ): Promise<void> {
-    if (options && typeof options === 'string') {
-      throw new ConfigurationError('unsupported operation: Cannot set encoding in browser');
-    }
-    if (isFirefox()) {
-      await fileSave(new Response(this.stream), {
-        fileName: filepath,
-        extensions: [`.${filepath.split('.').pop()}`],
-      });
-      return;
-    }
-
-    if (this.fileStreamServiceWorker) {
-      streamSaver.mitm = this.fileStreamServiceWorker;
-    }
-
-    const fileStream = streamSaver.createWriteStream(filepath, {
-      writableStrategy: { highWaterMark: 1 },
-      readableStrategy: { highWaterMark: 1 },
-    });
-
-    if (WritableStream) {
-      return this.stream.pipeTo(fileStream, options);
-    }
-
-    // Write (pipe) manually
-    const reader = this.stream.getReader();
-    const writer = fileStream.getWriter();
-    const pump = async (): Promise<void> => {
-      const res = await reader.read();
-
-      if (res.done) {
-        return await writer.close();
-      } else {
-        await writer.write(res.value);
-        return pump();
-      }
-    };
-    return pump();
-
-    // const pump = (): Promise<void> =>
-    //   reader.read().then((res) => (res.done ? writer.close() : writer.write(res.value).then(pump)));
-    // pump();
-  }
 }
 
 export function isDecoratedReadableStream(s: unknown): s is DecoratedReadableStream {
   return (
+    typeof (s as DecoratedReadableStream)?.stream !== 'undefined' &&
     typeof (s as DecoratedReadableStream)?.toBuffer !== 'undefined' &&
-    typeof (s as DecoratedReadableStream)?.toFile !== 'undefined' &&
     typeof (s as DecoratedReadableStream)?.toString !== 'undefined'
   );
 }

--- a/lib/tdf3/src/tdf.ts
+++ b/lib/tdf3/src/tdf.ts
@@ -1023,8 +1023,6 @@ export async function readStream(cfg: DecryptConfiguration) {
   const outputStream = new DecoratedReadableStream(underlyingSource);
 
   outputStream.manifest = manifest;
-  outputStream.emit('manifest', manifest);
   outputStream.metadata = metadata;
-  outputStream.emit('rewrap', metadata);
   return outputStream;
 }

--- a/web-app/package-lock.json
+++ b/web-app/package-lock.json
@@ -943,10 +943,9 @@
     "node_modules/@opentdf/sdk": {
       "version": "0.2.0",
       "resolved": "file:../lib/opentdf-sdk-0.2.0.tgz",
-      "integrity": "sha512-7hXtbo8HTy8eV7QZd+8aRLbUR8mEKSU+Zc5MKTCGIhGMc8uIRKMuTFoeCCRsUJUXH3RiNoujFoaZMSyc1ffbow==",
+      "integrity": "sha512-Ic6Tl6tV/TI9JPyjAnfywPen0t78JSkiupDKdpSVa2ZW8B69yU0oh65aC8oxniZJ57krRIFn/HxY1lX0HTk+TQ==",
       "license": "BSD-3-Clause-Clear",
       "dependencies": {
-        "base64-js": "^1.5.1",
         "browser-fs-access": "^0.34.1",
         "buffer-crc32": "^0.2.13",
         "dpop": "^1.2.0",
@@ -1823,6 +1822,7 @@
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4844,9 +4844,8 @@
     },
     "@opentdf/sdk": {
       "version": "file:../lib/opentdf-sdk-0.2.0.tgz",
-      "integrity": "sha512-7hXtbo8HTy8eV7QZd+8aRLbUR8mEKSU+Zc5MKTCGIhGMc8uIRKMuTFoeCCRsUJUXH3RiNoujFoaZMSyc1ffbow==",
+      "integrity": "sha512-Ic6Tl6tV/TI9JPyjAnfywPen0t78JSkiupDKdpSVa2ZW8B69yU0oh65aC8oxniZJ57krRIFn/HxY1lX0HTk+TQ==",
       "requires": {
-        "base64-js": "^1.5.1",
         "browser-fs-access": "^0.34.1",
         "buffer-crc32": "^0.2.13",
         "dpop": "^1.2.0",
@@ -5364,7 +5363,8 @@
       "dev": true
     },
     "base64-js": {
-      "version": "1.5.1"
+      "version": "1.5.1",
+      "dev": true
     },
     "brace-expansion": {
       "version": "1.1.11",

--- a/web-app/package-lock.json
+++ b/web-app/package-lock.json
@@ -13,7 +13,8 @@
         "clsx": "^2.1.1",
         "native-file-system-adapter": "^3.0.1",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "streamsaver": "^2.0.6"
       },
       "devDependencies": {
         "@playwright/test": "^1.48.2",
@@ -942,17 +943,15 @@
     "node_modules/@opentdf/sdk": {
       "version": "0.2.0",
       "resolved": "file:../lib/opentdf-sdk-0.2.0.tgz",
-      "integrity": "sha512-l6lK7So2oS9+j9W+59H3S36G64v2W/Un1iw6RDFhHfRmK21fM/bTnJC7apAjEQjO/mv8phNd1li0U9ninPgkAw==",
+      "integrity": "sha512-7hXtbo8HTy8eV7QZd+8aRLbUR8mEKSU+Zc5MKTCGIhGMc8uIRKMuTFoeCCRsUJUXH3RiNoujFoaZMSyc1ffbow==",
       "license": "BSD-3-Clause-Clear",
       "dependencies": {
         "base64-js": "^1.5.1",
         "browser-fs-access": "^0.34.1",
         "buffer-crc32": "^0.2.13",
         "dpop": "^1.2.0",
-        "eventemitter3": "^5.0.1",
         "jose": "^4.14.4",
         "json-canonicalize": "^1.0.6",
-        "streamsaver": "^2.0.6",
         "uuid": "~9.0.0"
       }
     },
@@ -2446,12 +2445,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/eventemitter3": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
-      "license": "MIT"
     },
     "node_modules/expect-type": {
       "version": "1.1.0",
@@ -4851,16 +4844,14 @@
     },
     "@opentdf/sdk": {
       "version": "file:../lib/opentdf-sdk-0.2.0.tgz",
-      "integrity": "sha512-l6lK7So2oS9+j9W+59H3S36G64v2W/Un1iw6RDFhHfRmK21fM/bTnJC7apAjEQjO/mv8phNd1li0U9ninPgkAw==",
+      "integrity": "sha512-7hXtbo8HTy8eV7QZd+8aRLbUR8mEKSU+Zc5MKTCGIhGMc8uIRKMuTFoeCCRsUJUXH3RiNoujFoaZMSyc1ffbow==",
       "requires": {
         "base64-js": "^1.5.1",
         "browser-fs-access": "^0.34.1",
         "buffer-crc32": "^0.2.13",
         "dpop": "^1.2.0",
-        "eventemitter3": "^5.0.1",
         "jose": "^4.14.4",
         "json-canonicalize": "^1.0.6",
-        "streamsaver": "^2.0.6",
         "uuid": "~9.0.0"
       }
     },
@@ -5746,11 +5737,6 @@
     "esutils": {
       "version": "2.0.3",
       "dev": true
-    },
-    "eventemitter3": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
     },
     "expect-type": {
       "version": "1.1.0",

--- a/web-app/package.json
+++ b/web-app/package.json
@@ -19,7 +19,8 @@
     "clsx": "^2.1.1",
     "native-file-system-adapter": "^3.0.1",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "streamsaver": "^2.0.6"
   },
   "devDependencies": {
     "@playwright/test": "^1.48.2",

--- a/web-app/src/App.tsx
+++ b/web-app/src/App.tsx
@@ -7,7 +7,6 @@ import { type Chunker, type DecryptSource, NanoTDFClient, TDF3Client } from '@op
 import { type SessionInformation, OidcClient } from './session.js';
 import { c } from './config.js';
 
-
 async function toFile(
   stream: ReadableStream<Uint8Array>,
   filepath = 'download.tdf',
@@ -16,7 +15,6 @@ async function toFile(
     signal?: AbortSignal;
   }
 ): Promise<void> {
-
   const fileStream = streamsaver.createWriteStream(filepath, {
     writableStrategy: { highWaterMark: 1 },
     readableStrategy: { highWaterMark: 1 },


### PR DESCRIPTION
This removes a dependency on streamsaver.js. The equivalent function to this method is now viewable in the `App.tsx` file:

```ts
async function toFile(
  stream: ReadableStream<Uint8Array>,
  filepath = 'download.tdf',
  options?: {
    encoding?: BufferEncoding;
    signal?: AbortSignal;
  }
): Promise<void> {

  const fileStream = streamsaver.createWriteStream(filepath, {
    writableStrategy: { highWaterMark: 1 },
    readableStrategy: { highWaterMark: 1 },
  });

  return stream.pipeTo(fileStream, options);
}
```