### PR TITLE
fix(cli): Better errors and properly set exit code in more cases

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -562,11 +562,8 @@ export const handleArgs = (args: string[]) => {
             log('DEBUG', `About to TDF3 decrypt [${argv.file}]`);
             const ct = await client.read(await parseReadOptions(argv));
             const destination = argv.output ? createWriteStream(argv.output) : process.stdout;
-            try {
-              await ct.pipeTo(Writable.toWeb(destination));
-            } catch (e) {
-              log('ERROR', `Failed to pipe to destination stream: ${e}`);
-            }
+            await ct.pipeTo(Writable.toWeb(destination));
+
             const lastRequest = authProvider.requestLog[authProvider.requestLog.length - 1];
             log('SILLY', `last request is ${JSON.stringify(lastRequest)}`);
             let accessToken = null;

--- a/lib/tdf3/src/models/key-access.ts
+++ b/lib/tdf3/src/models/key-access.ts
@@ -60,58 +60,7 @@ export class Wrapped {
   }
 }
 
-export class Remote {
-  readonly type = 'remote';
-  keyAccessObject?: KeyAccessObject;
-  wrappedKey?: string;
-  policyBinding?: string;
-
-  constructor(
-    public readonly url: string,
-    public readonly kid: string | undefined,
-    public readonly publicKey: string,
-    public readonly metadata: unknown,
-    public readonly sid: string
-  ) {}
-
-  async write(
-    policy: Policy,
-    keyBuffer: Uint8Array,
-    encryptedMetadataStr: string
-  ): Promise<KeyAccessObject> {
-    const policyStr = JSON.stringify(policy);
-    const policyBinding = await cryptoService.hmac(
-      hex.encodeArrayBuffer(keyBuffer),
-      base64.encode(policyStr)
-    );
-    const unwrappedKeyBinary = Binary.fromArrayBuffer(keyBuffer.buffer);
-    const wrappedKeyBinary = await cryptoService.encryptWithPublicKey(
-      unwrappedKeyBinary,
-      this.publicKey
-    );
-
-    // this.wrappedKey = wrappedKeyBinary.asBuffer().toString('hex');
-    this.wrappedKey = base64.encode(wrappedKeyBinary.asString());
-
-    this.keyAccessObject = {
-      type: 'remote',
-      url: this.url,
-      protocol: 'kas',
-      wrappedKey: this.wrappedKey,
-      encryptedMetadata: base64.encode(encryptedMetadataStr),
-      policyBinding: {
-        alg: 'HS256',
-        hash: base64.encode(policyBinding),
-      },
-    };
-    if (this.kid) {
-      this.keyAccessObject.kid = this.kid;
-    }
-    return this.keyAccessObject;
-  }
-}
-
-export type KeyAccess = Remote | Wrapped;
+export type KeyAccess = Wrapped;
 
 export type KeyAccessObject = {
   sid?: string;

--- a/lib/tdf3/src/tdf.ts
+++ b/lib/tdf3/src/tdf.ts
@@ -858,7 +858,9 @@ export async function sliceAndDecrypt({
         isLegacyTDF
       );
       if (plainSegmentSize && result.payload.length() !== plainSegmentSize) {
-        throw new DecryptError(`incorrect segment size: found [${result.payload.length()}], expected [${plainSegmentSize}]`);
+        throw new DecryptError(
+          `incorrect segment size: found [${result.payload.length()}], expected [${plainSegmentSize}]`
+        );
       }
       slice[index].decryptedChunk.set(result);
     } catch (e) {
@@ -950,20 +952,26 @@ export async function readStream(cfg: DecryptConfiguration) {
 
   let mapOfRequestsOffset = 0;
   const chunkMap = new Map(
-    segments.map(({ hash, encryptedSegmentSize = encryptedSegmentSizeDefault, segmentSize = segmentSizeDefault }) => {
-      const result = (() => {
-        const chunk: Chunk = {
-          hash,
-          encryptedOffset: mapOfRequestsOffset,
-          encryptedSegmentSize,
-          decryptedChunk: mailbox<DecryptResult>(),
-          plainSegmentSize: segmentSize,
-        };
-        return chunk;
-      })();
-      mapOfRequestsOffset += encryptedSegmentSize;
-      return [hash, result];
-    })
+    segments.map(
+      ({
+        hash,
+        encryptedSegmentSize = encryptedSegmentSizeDefault,
+        segmentSize = segmentSizeDefault,
+      }) => {
+        const result = (() => {
+          const chunk: Chunk = {
+            hash,
+            encryptedOffset: mapOfRequestsOffset,
+            encryptedSegmentSize,
+            decryptedChunk: mailbox<DecryptResult>(),
+            plainSegmentSize: segmentSize,
+          };
+          return chunk;
+        })();
+        mapOfRequestsOffset += encryptedSegmentSize;
+        return [hash, result];
+      }
+    )
   );
 
   const cipher = new AesGcmCipher(cfg.cryptoService);

--- a/lib/tdf3/src/tdf.ts
+++ b/lib/tdf3/src/tdf.ts
@@ -35,7 +35,6 @@ import {
   KeyInfo,
   Manifest,
   Policy,
-  Remote as KeyAccessRemote,
   SplitKey,
   Wrapped as KeyAccessWrapped,
   KeyAccess,
@@ -219,10 +218,8 @@ export async function buildKeyAccess({
     switch (type) {
       case 'wrapped':
         return new KeyAccessWrapped(kasUrl, kasKeyIdentifier, pubKey, metadata, sid);
-      case 'remote':
-        return new KeyAccessRemote(kasUrl, kasKeyIdentifier, pubKey, metadata, sid);
       default:
-        throw new ConfigurationError(`buildKeyAccess: Key access type ${type} is unknown`);
+        throw new ConfigurationError(`buildKeyAccess: Key access type [${type}] is unsupported`);
     }
   }
 

--- a/lib/tdf3/src/tdf.ts
+++ b/lib/tdf3/src/tdf.ts
@@ -922,14 +922,6 @@ export async function readStream(cfg: DecryptConfiguration) {
     integrityAlgorithm
   );
 
-  const rootSig = isLegacyTDF
-    ? base64.encode(hex.encodeArrayBuffer(payloadSig))
-    : base64.encodeArrayBuffer(payloadSig);
-
-  if (manifest.encryptionInformation.integrityInformation.rootSignature.sig !== rootSig) {
-    throw new IntegrityError('Failed integrity check on root signature');
-  }
-
   if (!cfg.noVerifyAssertions) {
     for (const assertion of manifest.assertions || []) {
       // Create a default assertion key
@@ -946,6 +938,14 @@ export async function readStream(cfg: DecryptConfiguration) {
       }
       await assertions.verify(assertion, aggregateHash, assertionKey, isLegacyTDF);
     }
+  }
+
+  const rootSig = isLegacyTDF
+    ? base64.encode(hex.encodeArrayBuffer(payloadSig))
+    : base64.encodeArrayBuffer(payloadSig);
+
+  if (manifest.encryptionInformation.integrityInformation.rootSignature.sig !== rootSig) {
+    throw new IntegrityError('Failed integrity check on root signature');
   }
 
   let mapOfRequestsOffset = 0;

--- a/lib/tests/mocha/unit/tdf.spec.ts
+++ b/lib/tests/mocha/unit/tdf.spec.ts
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 
 import * as TDF from '../../../tdf3/src/tdf.js';
 import { KeyAccessObject } from '../../../tdf3/src/models/key-access.js';
+import { PolicyBody, type Policy } from '../../../tdf3/src/models/policy.js';
 import { OriginAllowList } from '../../../src/access.js';
 import { ConfigurationError, InvalidFileError, UnsafeUrlError } from '../../../src/errors.js';
 
@@ -95,6 +96,43 @@ describe('fetchKasPublicKey', async () => {
         throw e;
       }).to.throw(ConfigurationError);
     }
+  });
+});
+
+describe('validatePolicyObject', () => {
+  const testCases: { title: string; policy: Partial<Policy>; error?: string }[] = [
+    {
+      title: 'missing uuid',
+      policy: { body: { dataAttributes: [], dissem: ['someDissem'] } },
+      error: 'uuid',
+    },
+    {
+      title: 'missing body',
+      policy: { uuid: 'someUuid' },
+      error: 'body',
+    },
+    {
+      title: 'missing body.dissem',
+      policy: { uuid: 'someUuid', body: {} as PolicyBody },
+      error: 'dissem',
+    },
+    {
+      title: 'valid policy',
+      policy: { uuid: 'someUuid', body: { dataAttributes: [], dissem: ['someDissem'] } },
+    },
+  ];
+
+  testCases.forEach(({ title, policy, error }) => {
+    it(`should handle ${title}`, () => {
+      if (error) {
+        expect(() => TDF.validatePolicyObject(policy as Policy)).to.throw(
+          ConfigurationError,
+          error
+        );
+      } else {
+        expect(() => TDF.validatePolicyObject(policy as Policy)).to.not.throw();
+      }
+    });
   });
 });
 


### PR DESCRIPTION
- validates assertions before validating root sig (faster, errors match those expected in xtest)
- removes some unused code (remote keys)
- lets CLI tool properly return non-zero status code on more conditions
