### PR TITLE
chore(ci): Don't run sonarscan for dependabot PRs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,8 +2,9 @@ name: Build, Test, and Deliver Client
 
 env:
   do_sonarscan: >-
-    ${{ github.event_name == 'push' ||
-      github.event.pull_request.head.repo.full_name == github.repository }}
+    ${{ (github.event_name == 'push' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      github.actor != 'dependabot[bot]' }}
 
 on:
   pull_request:


### PR DESCRIPTION
- Dependabot PRs [behave like fork PRs](https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/), so they don't have access to the sonarqube secret
- Instead, skip the step where the results are pushed to sonarcloud [when appropriate](https://docs.github.com/en/code-security/dependabot/troubleshooting-dependabot/troubleshooting-dependabot-on-github-actions#troubleshooting-failures-when-dependabot-triggers-existing-workflows)