### PR TITLE
fix(sdk): Lets new API set nano binding type

### DIFF
--- a/cli/bin/opentdf.bats
+++ b/cli/bin/opentdf.bats
@@ -23,5 +23,5 @@
   run $BATS_TEST_DIRNAME/opentdf.mjs --version
   echo "$output"
   [[ $output == *"@opentdf/sdk\":\""* ]]
-  [[ $output == *"@opentdf/ctl\":\""* ]]
+  [[ $output == *"tdfSpecVersion\":\""* ]]
 }

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -653,7 +653,6 @@ export const handleArgs = (args: string[]) => {
       .version(
         'version',
         JSON.stringify({
-          '@opentdf/ctl': process.env.npm_package_version || 'UNRELEASED',
           '@opentdf/sdk': version,
           tdfSpecVersion,
         })


### PR DESCRIPTION
- The new API broke selecting between ECDSA and GMAC policy binding options
- This adds that feature back and fixes it in the command line tool
- Removes the incorrect ctl version number from the command line tool, as it has never returned the correct value.
- Exposes a few more missing exports that are still stuck behind the `from '@opentdf/sdk/singlecontainer'` import that integrators are actively using