### PR TITLE
chore(ci): Let xtest focus on this sdk

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -213,6 +213,7 @@ jobs:
       - lib
     uses: opentdf/tests/.github/workflows/xtest.yml@main
     with:
+      focus-sdk: js
       js-ref: ${{ github.ref }}
 
   deliver-ghp:


### PR DESCRIPTION
Seems to speed up the job significantly. This run is down to 10m 32s after previously taking 18m 6s.

<img width="693" alt="image" src="https://github.com/user-attachments/assets/eef7ce42-697f-490a-bbe2-f8fc966fc780" />
