### PR TITLE
fix(sdk): Removes ntdf version header

### DIFF
--- a/lib/src/access.ts
+++ b/lib/src/access.ts
@@ -38,7 +38,6 @@ export async function fetchWrappedKey(
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      'virtru-ntdf-version': clientVersion,
     },
     body: JSON.stringify(requestBody),
   });

--- a/lib/tests/server.ts
+++ b/lib/tests/server.ts
@@ -66,7 +66,7 @@ const kas: RequestListener = async (req, res) => {
   console.log('[INFO]: server request: ', req.method, req.url, req.headers);
   res.setHeader(
     'Access-Control-Allow-Headers',
-    'authorization, content-type, dpop, range, virtru-ntdf-version, x-test-response, x-test-response-message'
+    'authorization, content-type, dpop, range, x-test-response, x-test-response-message'
   );
   res.setHeader('Access-Control-Allow-Origin', '*');
   // GET should be allowed for everything except rewrap, POST only for rewrap but IDC


### PR DESCRIPTION
This was for debugging an old issue with v1 of the platform, and is not supported in v2