### PR TITLE
fix(sdk):  support hex encoding signature hash for legacy sdk

### DIFF
--- a/.github/workflows/roundtrip/encrypt-decrypt.sh
+++ b/.github/workflows/roundtrip/encrypt-decrypt.sh
@@ -17,7 +17,7 @@ _nano_test() {
     --oidcEndpoint http://localhost:65432/auth/realms/opentdf \
     --auth testclient:secret \
     --output sample.txt.ntdf \
-    encrypt "${plain}" 
+    encrypt "${plain}"
 
   [ -f sample.txt.ntdf ]
 
@@ -48,7 +48,8 @@ _tdf3_test() {
     --auth testclient:secret \
     --output sample.txt.tdf \
     encrypt "${plain}" \
-    --containerType tdf3 
+    --containerType tdf3 \
+    --tdfSpecVersion "$3"
 
   [ -f sample.txt.tdf ]
 
@@ -67,7 +68,8 @@ _tdf3_test() {
   rm -f "${plain}" sample.txt.tdf sample_out.txt
 }
 
-_tdf3_test @opentdf/ctl @opentdf/ctl
+_tdf3_test @opentdf/ctl @opentdf/ctl "4.2.2"
+_tdf3_test @opentdf/ctl @opentdf/ctl "4.3.0"
 
 _tdf3_inspect_test() {
   counter=$((counter + 1))
@@ -81,7 +83,7 @@ _tdf3_inspect_test() {
     --output sample-with-attrs.txt.tdf \
     --attributes 'https://attr.io/attr/a/value/1,https://attr.io/attr/x/value/2' \
     encrypt "${plain}" \
-    --containerType tdf3 
+    --containerType tdf3
 
   [ -f sample-with-attrs.txt.tdf ]
 

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -302,6 +302,9 @@ async function parseCreateZTDFOptions(argv: Partial<mainArgs>): Promise<CreateZT
       throw new CLIError('CRITICAL', 'Invalid mimeType format');
     }
   }
+  if (argv.tdfSpecVersion) {
+    c.tdfSpecVersion = argv.tdfSpecVersion as never;
+  }
   log('DEBUG', `CreateZTDFOptions: ${JSON.stringify(c)}`);
   return c;
 }
@@ -506,6 +509,12 @@ export const handleArgs = (args: string[]) => {
           group: 'Encrypt Options:',
           type: 'string',
           description: 'Owner email address',
+        },
+        tdfSpecVersion: {
+          group: 'Encrypt Options:',
+          type: 'string',
+          description: 'TDF spec version for file creation',
+          default: tdfSpecVersion,
         },
       })
 

--- a/lib/package-lock.json
+++ b/lib/package-lock.json
@@ -8938,8 +8938,9 @@
     },
     "node_modules/semver": {
       "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "dev": true,
-      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },

--- a/lib/src/opentdf.ts
+++ b/lib/src/opentdf.ts
@@ -127,6 +127,9 @@ export type CreateZTDFOptions = CreateOptions & {
 
   // Preferred algorithm to use for Key Access Objects.
   wrappingKeyAlgorithm?: KasPublicKeyAlgorithm;
+
+  // TDF spec version to target
+  tdfSpecVersion?: '4.2.2' | '4.3.0';
 };
 
 // Settings for decrypting any variety of TDF file.
@@ -366,6 +369,7 @@ export class OpenTDF {
       splitPlan: opts.splitPlan,
       windowSize: opts.windowSize,
       wrappingKeyAlgorithm: opts.wrappingKeyAlgorithm,
+      tdfSpecVersion: opts.tdfSpecVersion ?? '4.3.0',
     });
     const stream: DecoratedStream = oldStream.stream;
     stream.manifest = Promise.resolve(oldStream.manifest);

--- a/lib/tdf3/src/client/builders.ts
+++ b/lib/tdf3/src/client/builders.ts
@@ -59,6 +59,8 @@ export type EncryptParams = {
   asHtml?: boolean;
   // Unsupported
   offline?: boolean;
+  // TDF spec version to target
+  tdfSpecVersion?: string;
 };
 
 // 'Readonly<EncryptParams>': scope, metadata, offline, windowSize, asHtml


### PR DESCRIPTION
**Motivation**
Hex encoding signature was removed here https://github.com/opentdf/web-sdk/pull/397 

For **decryption** `isLegacyTDF` flag was used during decryption to determine if `base64` or `base64+hex` encoding of signatures was required for the hash.
For **encryption** only `base64` was used.

Because encryption is done only with `base64` signature hashes this produces an incompatibility with legacy clients that expect the signature hash to be `base64+hex`.

Moving forward, we do not want to use `base64+hex` but we need to allow current clients to be able to encrypt files that legacy files can decrypt. This is where the motivation for this PR changes come from.

**PR Changes**
- Add `targetSpecVersion` to  `EncryptConfiguration` to force legacy encryption 
- Add `targetSpecVersion` to `generateManifest` function to allow forcing legacy tdf spec
- Add `getSignatureHash422` function to return the correct hash format for legacy mode



