### PR TITLE
chore(ci): Fix prefix submatch operator for tags

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -261,7 +261,7 @@ jobs:
           if [[ ${{ github.ref }} = refs/heads/release/* ]]; then
             scripts/check-version-is.sh "${GITHUB_REF##*release/}"
           elif [[ ${{ github.ref }} = refs/tags/sdk/v* ]]; then
-            scripts/check-version-is.sh "${GITHUB_REF_NAME#v}"
+            scripts/check-version-is.sh "${GITHUB_REF_NAME#sdk/v}"
           else
             scripts/check-version-is.sh
           fi


### PR DESCRIPTION
- This should remove the prefix before the semver in the ref name