### PR TITLE
chore(ci): Replace chainguard keycloak image

### DIFF
--- a/.github/workflows/roundtrip/docker-compose.yaml
+++ b/.github/workflows/roundtrip/docker-compose.yaml
@@ -1,7 +1,6 @@
 services:
   keycloak:
-    # This is kc 24.0.1 with opentdf protocol mapper on board
-    image: cgr.dev/chainguard/keycloak@sha256:37895558d2e0e93ffff75da5900f9ae7e79ec6d1c390b18b2ecea6cee45ec26f
+    image: keycloak/keycloak:25.0
     restart: always
     command:
     - "start-dev"


### PR DESCRIPTION
These are no longer available for free tier users, let along unauthenticated ones