### PR TITLE
feat(sdk): get KASes list from platform when allowedKases list is not passed

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -614,7 +614,7 @@ export const handleArgs = (args: string[]) => {
         },
         async (argv) => {
           log('DEBUG', 'Running decrypt command');
-          let allowedKases = argv.allowList?.split(',');
+          const allowedKases = argv.allowList?.split(',');
           log('DEBUG', `Allowed KASes: ${allowedKases}`);
           const ignoreAllowList = !!argv.ignoreAllowList;
           if (!argv.oidcEndpoint) {

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -379,7 +379,7 @@ export const handleArgs = (args: string[]) => {
       })
       .option('allowList', {
         group: 'Security:',
-        desc: 'allowed KAS origins, comma separated; defaults to [kasEndpoint]',
+        desc: 'allowed KAS origins, comma separated; defaults to the list from "/key-access-servers" endpoint',
         type: 'string',
         validate: (uris: string) => uris.split(','),
       })
@@ -615,9 +615,6 @@ export const handleArgs = (args: string[]) => {
         async (argv) => {
           log('DEBUG', 'Running decrypt command');
           let allowedKases = argv.allowList?.split(',');
-          if (!allowedKases) {
-            allowedKases = argv.kasEndpoint ? [argv.kasEndpoint] : [];
-          }
           log('DEBUG', `Allowed KASes: ${allowedKases}`);
           const ignoreAllowList = !!argv.ignoreAllowList;
           if (!argv.oidcEndpoint) {

--- a/lib/src/access.ts
+++ b/lib/src/access.ts
@@ -156,6 +156,14 @@ async function noteInvalidPublicKey(url: URL, r: Promise<CryptoKey>): Promise<Cr
   }
 }
 
+export async function fetchKeyAccessServers(platformUrl: string): Promise<OriginAllowList> {
+  // TODO KAS: fetch the list correctly and test it /key-access-servers
+  // This should allow for the tests to pass but it needs to be replaced with
+  // '/policy.kasregistry.KeyAccessServerRegistryService/ListKeyAccessServers'
+  console.log('TODO fetchKeyAccessServers', platformUrl);
+  return new OriginAllowList([platformUrl], false);
+}
+
 /**
  * If we have KAS url but not public key we can fetch it from KAS, fetching
  * the value from `${kas}/kas_public_key`.

--- a/lib/src/nanotdf/Client.ts
+++ b/lib/src/nanotdf/Client.ts
@@ -227,7 +227,7 @@ export default class Client {
     let allowedKases = this.allowedKases;
 
     if (!allowedKases) {
-      allowedKases = await fetchKeyAccessServers(this.platformUrl);
+      allowedKases = await fetchKeyAccessServers(this.platformUrl, this.authProvider);
     }
 
     if (!allowedKases.allows(kasRewrapUrl)) {

--- a/lib/src/nanotdf/Client.ts
+++ b/lib/src/nanotdf/Client.ts
@@ -181,8 +181,8 @@ export default class Client {
       validateSecureUrl(kasEndpoint);
       this.kasUrl = kasEndpoint;
       this.platformUrl = platformUrl;
-      if (allowedKases?.length) {
-        this.allowedKases = new OriginAllowList(allowedKases, !!ignoreAllowList);
+      if (allowedKases?.length || ignoreAllowList) {
+        this.allowedKases = new OriginAllowList(allowedKases || [], ignoreAllowList);
       }
       this.dpopEnabled = !!dpopEnabled;
       if (dpopKeys) {

--- a/lib/src/nanotdf/Client.ts
+++ b/lib/src/nanotdf/Client.ts
@@ -148,6 +148,7 @@ export default class Client {
         throw new ConfigurationError('please specify kasEndpoint');
       }
       // TODO Disallow http KAS. For now just log as error
+      // TODO KAS: check here in PR please
       validateSecureUrl(kasUrl);
       this.kasUrl = kasUrl;
       this.allowedKases = new OriginAllowList([kasUrl]);
@@ -171,6 +172,7 @@ export default class Client {
       } = optsOrOldAuthProvider;
       this.authProvider = enwrapAuthProvider(authProvider);
       // TODO Disallow http KAS. For now just log as error
+      // TODO KAS: fix here
       validateSecureUrl(kasEndpoint);
       this.kasUrl = kasEndpoint;
       this.allowedKases = new OriginAllowList(allowedKases || [kasEndpoint], !!ignoreAllowList);
@@ -214,6 +216,7 @@ export default class Client {
     magicNumberVersion: ArrayBufferLike,
     clientVersion: string
   ): Promise<CryptoKey> {
+    // TODO KAS: fix here for real
     if (!this.allowedKases.allows(kasRewrapUrl)) {
       throw new UnsafeUrlError(`request URL ∉ ${this.allowedKases.origins};`, kasRewrapUrl);
     }

--- a/lib/src/opentdf.ts
+++ b/lib/src/opentdf.ts
@@ -13,7 +13,12 @@ import {
   AssertionConfig,
   AssertionVerificationKeys,
 } from '../tdf3/src/assertions.js';
-import { type KasPublicKeyAlgorithm, OriginAllowList, isPublicKeyAlgorithm } from './access.js';
+import {
+  type KasPublicKeyAlgorithm,
+  OriginAllowList,
+  fetchKeyAccessServers,
+  isPublicKeyAlgorithm,
+} from './access.js';
 import { type Manifest } from '../tdf3/src/models/manifest.js';
 import { type Payload } from '../tdf3/src/models/payload.js';
 import {
@@ -87,6 +92,7 @@ export type CreateNanoTDFOptions = CreateOptions & {
 };
 
 export type CreateNanoTDFCollectionOptions = CreateNanoTDFOptions & {
+  platformUrl: string;
   // The maximum number of key iterations to use for a single DEK.
   maxKeyIterations?: number;
 };
@@ -136,6 +142,8 @@ export type CreateZTDFOptions = CreateOptions & {
 export type ReadOptions = {
   // ciphertext
   source: Source;
+  // Platform URL
+  platformUrl?: string;
   // list of KASes that may be contacted for a rewrap
   allowedKASEndpoints?: string[];
   // Optionally disable checking the allowlist
@@ -156,6 +164,9 @@ export type ReadOptions = {
 export type OpenTDFOptions = {
   // Policy service endpoint
   policyEndpoint?: string;
+
+  // Platform URL
+  platformUrl?: string;
 
   // Auth provider for connections to the policy service and KASes.
   authProvider: AuthProvider;
@@ -286,6 +297,7 @@ export type TDFReader = {
 // SDK for dealing with OpenTDF data and policy services.
 export class OpenTDF {
   // Configuration service and more is at this URL/connectRPC endpoint
+  readonly platformUrl: string;
   readonly policyEndpoint: string;
   readonly authProvider: AuthProvider;
   readonly dpopEnabled: boolean;
@@ -305,11 +317,15 @@ export class OpenTDF {
     disableDPoP,
     policyEndpoint,
     rewrapCacheOptions,
+    platformUrl,
   }: OpenTDFOptions) {
     this.authProvider = authProvider;
     this.defaultCreateOptions = defaultCreateOptions || {};
     this.defaultReadOptions = defaultReadOptions || {};
     this.dpopEnabled = !!disableDPoP;
+    if (platformUrl) {
+      this.platformUrl = platformUrl;
+    }
     this.policyEndpoint = policyEndpoint || '';
     this.rewrapCache = new RewrapCache(rewrapCacheOptions);
     this.tdf3Client = new TDF3Client({
@@ -333,8 +349,14 @@ export class OpenTDF {
   }
 
   async createNanoTDF(opts: CreateNanoTDFOptions): Promise<DecoratedStream> {
-    opts = { ...this.defaultCreateOptions, ...opts };
-    const collection = await this.createNanoTDFCollection(opts);
+    opts = {
+      ...this.defaultCreateOptions,
+      ...opts,
+    };
+    const collection = await this.createNanoTDFCollection({
+      ...opts,
+      platformUrl: this.platformUrl,
+    });
     try {
       return await collection.encrypt(opts.source);
     } finally {
@@ -415,6 +437,9 @@ class UnknownTypeReader {
     this.state = 'resolving';
     const chunker = await fromSource(this.opts.source);
     const prefix = await chunker(0, 3);
+    if (!this.opts.platformUrl && this.outer.platformUrl) {
+      this.opts.platformUrl = this.outer.platformUrl;
+    }
     if (prefix[0] === 0x50 && prefix[1] === 0x4b) {
       this.state = 'loaded';
       return new ZTDFReader(this.outer.tdf3Client, this.opts, chunker);
@@ -466,6 +491,9 @@ class NanoTDFReader {
     readonly chunker: Chunker,
     private readonly rewrapCache: RewrapCache
   ) {
+    if (!this.outer.platformUrl && !this.opts.allowedKASEndpoints?.length) {
+      throw new ConfigurationError('platformUrl is required when allowedKasEndpoints is empty');
+    }
     // lazily load the container
     this.container = new Promise(async (resolve, reject) => {
       try {
@@ -478,7 +506,6 @@ class NanoTDFReader {
     });
   }
 
-  // TODO KAS: Check here in the PR please
   async decrypt(): Promise<DecoratedStream> {
     const nanotdf = await this.container;
     const cachedDEK = this.rewrapCache.get(nanotdf.header.ephemeralPublicKey);
@@ -494,6 +521,7 @@ class NanoTDFReader {
       dpopEnabled: this.outer.dpopEnabled,
       dpopKeys: this.outer.dpopKeys,
       kasEndpoint: this.opts.allowedKASEndpoints?.[0] || 'https://disallow.all.invalid',
+      platformUrl: this.outer.platformUrl,
     });
     // TODO: The version number should be fetched from the API
     const version = '0.0.1';
@@ -551,11 +579,19 @@ class ZTDFReader {
       noVerify: noVerifyAssertions,
       wrappingKeyAlgorithm,
     } = this.opts;
-    // TODO fix here ?
-    const allowList = new OriginAllowList(
-      this.opts.allowedKASEndpoints ?? [],
-      this.opts.ignoreAllowlist
-    );
+
+    if (!this.opts.allowedKASEndpoints && !this.opts.platformUrl) {
+      throw new ConfigurationError('platformUrl is required when allowedKasEndpoints is empty');
+    }
+
+    let allowList: OriginAllowList | undefined;
+
+    if (this.opts.allowedKASEndpoints?.length) {
+      allowList = new OriginAllowList(this.opts.allowedKASEndpoints, this.opts.ignoreAllowlist);
+    } else if (this.opts.platformUrl) {
+      allowList = await fetchKeyAccessServers(this.opts.platformUrl);
+    }
+
     const dpopKeys = await this.client.dpopKeys;
 
     const { authProvider, cryptoService } = this.client;
@@ -648,6 +684,7 @@ class Collection {
       authProvider,
       kasEndpoint: opts.defaultKASEndpoint ?? 'https://disallow.all.invalid',
       maxKeyIterations: opts.maxKeyIterations,
+      platformUrl: opts.platformUrl,
     });
   }
 

--- a/lib/src/opentdf.ts
+++ b/lib/src/opentdf.ts
@@ -491,7 +491,11 @@ class NanoTDFReader {
     readonly chunker: Chunker,
     private readonly rewrapCache: RewrapCache
   ) {
-    if (!this.outer.platformUrl && !this.opts.allowedKASEndpoints?.length) {
+    if (
+      !this.opts.ignoreAllowlist &&
+      !this.outer.platformUrl &&
+      !this.opts.allowedKASEndpoints?.length
+    ) {
       throw new ConfigurationError('platformUrl is required when allowedKasEndpoints is empty');
     }
     // lazily load the container
@@ -580,14 +584,17 @@ class ZTDFReader {
       wrappingKeyAlgorithm,
     } = this.opts;
 
-    if (!this.opts.allowedKASEndpoints && !this.opts.platformUrl) {
+    if (!this.opts.ignoreAllowlist && !this.opts.allowedKASEndpoints && !this.opts.platformUrl) {
       throw new ConfigurationError('platformUrl is required when allowedKasEndpoints is empty');
     }
 
     let allowList: OriginAllowList | undefined;
 
-    if (this.opts.allowedKASEndpoints?.length) {
-      allowList = new OriginAllowList(this.opts.allowedKASEndpoints, this.opts.ignoreAllowlist);
+    if (this.opts.allowedKASEndpoints?.length || this.opts.ignoreAllowlist) {
+      allowList = new OriginAllowList(
+        this.opts.allowedKASEndpoints || [],
+        this.opts.ignoreAllowlist
+      );
     } else if (this.opts.platformUrl) {
       allowList = await fetchKeyAccessServers(this.opts.platformUrl);
     }

--- a/lib/src/opentdf.ts
+++ b/lib/src/opentdf.ts
@@ -478,6 +478,7 @@ class NanoTDFReader {
     });
   }
 
+  // TODO KAS: Check here in the PR please
   async decrypt(): Promise<DecoratedStream> {
     const nanotdf = await this.container;
     const cachedDEK = this.rewrapCache.get(nanotdf.header.ephemeralPublicKey);
@@ -550,6 +551,7 @@ class ZTDFReader {
       noVerify: noVerifyAssertions,
       wrappingKeyAlgorithm,
     } = this.opts;
+    // TODO fix here ?
     const allowList = new OriginAllowList(
       this.opts.allowedKASEndpoints ?? [],
       this.opts.ignoreAllowlist

--- a/lib/src/opentdf.ts
+++ b/lib/src/opentdf.ts
@@ -325,6 +325,10 @@ export class OpenTDF {
     this.dpopEnabled = !!disableDPoP;
     if (platformUrl) {
       this.platformUrl = platformUrl;
+    } else {
+      console.warn(
+        "Warning: 'platformUrl' is required for security to ensure the SDK uses the platform-configured Key Access Server list"
+      );
     }
     this.policyEndpoint = policyEndpoint || '';
     this.rewrapCache = new RewrapCache(rewrapCacheOptions);

--- a/lib/src/opentdf.ts
+++ b/lib/src/opentdf.ts
@@ -588,6 +588,13 @@ class ZTDFReader {
       throw new ConfigurationError('platformUrl is required when allowedKasEndpoints is empty');
     }
 
+    const dpopKeys = await this.client.dpopKeys;
+
+    const { authProvider, cryptoService } = this.client;
+    if (!authProvider) {
+      throw new ConfigurationError('authProvider is required');
+    }
+
     let allowList: OriginAllowList | undefined;
 
     if (this.opts.allowedKASEndpoints?.length || this.opts.ignoreAllowlist) {
@@ -596,14 +603,7 @@ class ZTDFReader {
         this.opts.ignoreAllowlist
       );
     } else if (this.opts.platformUrl) {
-      allowList = await fetchKeyAccessServers(this.opts.platformUrl);
-    }
-
-    const dpopKeys = await this.client.dpopKeys;
-
-    const { authProvider, cryptoService } = this.client;
-    if (!authProvider) {
-      throw new ConfigurationError('authProvider is required');
+      allowList = await fetchKeyAccessServers(this.opts.platformUrl, authProvider);
     }
 
     const overview = await this.overview;

--- a/lib/tdf3/src/client/index.ts
+++ b/lib/tdf3/src/client/index.ts
@@ -547,7 +547,7 @@ export class Client {
     if (!allowList && this.allowedKases) {
       allowList = this.allowedKases;
     } else if (this.platformUrl) {
-      allowList = await fetchKeyAccessServers(this.platformUrl);
+      allowList = await fetchKeyAccessServers(this.platformUrl, this.authProvider);
     } else {
       throw new ConfigurationError('platformUrl is required when allowedKases is empty');
     }

--- a/lib/tdf3/src/client/index.ts
+++ b/lib/tdf3/src/client/index.ts
@@ -39,6 +39,7 @@ import {
   EncryptParamsBuilder,
 } from './builders.js';
 import {
+  fetchKeyAccessServers,
   type KasPublicKeyInfo,
   keyAlgorithmToPublicKeyAlgorithm,
   OriginAllowList,
@@ -125,7 +126,7 @@ export interface ClientConfig {
   clientId?: string;
   dpopEnabled?: boolean;
   dpopKeys?: Promise<CryptoKeyPair>;
-  kasEndpoint?: string;
+  kasEndpoint: string;
   /**
    * Service to use to look up ABAC. Used during autoconfigure. Defaults to
    * kasEndpoint without the trailing `/kas` path segment, if present.
@@ -133,9 +134,11 @@ export interface ClientConfig {
   policyEndpoint?: string;
   /**
    * List of allowed KASes to connect to for rewrap requests.
-   * Defaults to `[kasEndpoint]`.
+   * Defaults to `[]`.
    */
   allowedKases?: string[];
+  // Platform URL to use to lookup allowed KASes when allowedKases is empty
+  platformUrl?: string;
   ignoreAllowList?: boolean;
   easEndpoint?: string;
   // DEPRECATED Ignored
@@ -237,7 +240,12 @@ export class Client {
    * List of allowed KASes to connect to for rewrap requests.
    * Defaults to `[this.kasEndpoint]`.
    */
-  readonly allowedKases: OriginAllowList;
+  readonly allowedKases?: OriginAllowList;
+
+  /**
+   * URL of the platform, required to fetch list of allowed KASes when allowedKases is empty
+   */
+  readonly platformUrl?: string;
 
   readonly kasKeys: Record<string, Promise<KasPublicKeyInfo>[]> = {};
 
@@ -287,6 +295,14 @@ export class Client {
       this.kasEndpoint = clientConfig.keyRewrapEndpoint.replace(/\/rewrap$/, '');
     }
     this.kasEndpoint = rstrip(this.kasEndpoint, '/');
+
+    if (!validateSecureUrl(this.kasEndpoint)) {
+      throw new ConfigurationError(`Invalid KAS endpoint [${this.kasEndpoint}]`);
+    }
+    if (config.platformUrl) {
+      this.platformUrl = config.platformUrl;
+    }
+
     if (clientConfig.policyEndpoint) {
       this.policyEndpoint = rstrip(clientConfig.policyEndpoint, '/');
     } else if (this.kasEndpoint.endsWith('/kas')) {
@@ -299,17 +315,12 @@ export class Client {
         clientConfig.allowedKases,
         !!clientConfig.ignoreAllowList
       );
-      if (!validateSecureUrl(this.kasEndpoint) && !this.allowedKases.allows(kasOrigin)) {
-        throw new ConfigurationError(`Invalid KAS endpoint [${this.kasEndpoint}]`);
-      }
-    } else {
-      // TODO KAS: fix here
-      if (!validateSecureUrl(this.kasEndpoint)) {
+      if (!this.allowedKases.allows(kasOrigin)) {
+        // TODO PR: ask if in this cases it makes more sense to add defaultKASEndpoint to the allow list if the allowList is not empty but doesn't have the defaultKas
         throw new ConfigurationError(
-          `Invalid KAS endpoint [${this.kasEndpoint}]; to force, please list it among allowedKases`
+          `Invalid KAS endpoint [${this.kasEndpoint}]. When allowedKases is set, defaultKASEndpoint needs to be in the allow list`
         );
       }
-      this.allowedKases = new OriginAllowList([kasOrigin], !!clientConfig.ignoreAllowList);
     }
 
     this.authProvider = config.authProvider;
@@ -518,8 +529,6 @@ export class Client {
    * @return a {@link https://nodejs.org/api/stream.html#stream_class_stream_readable|Readable} stream containing the decrypted plaintext.
    * @see DecryptParamsBuilder
    */
-
-  // TODO KAS: fix here
   async decrypt({
     source,
     allowList,
@@ -535,9 +544,12 @@ export class Client {
       throw new ConfigurationError('AuthProvider missing');
     }
     const chunker = await makeChunkable(source);
-    // TODO KAS: fix here for real
-    if (!allowList) {
+    if (!allowList && this.allowedKases) {
       allowList = this.allowedKases;
+    } else if (this.platformUrl) {
+      allowList = await fetchKeyAccessServers(this.platformUrl);
+    } else {
+      throw new ConfigurationError('platformUrl is required when allowedKases is empty');
     }
 
     // Await in order to catch any errors from this call.

--- a/lib/tdf3/src/client/index.ts
+++ b/lib/tdf3/src/client/index.ts
@@ -303,6 +303,7 @@ export class Client {
         throw new ConfigurationError(`Invalid KAS endpoint [${this.kasEndpoint}]`);
       }
     } else {
+      // TODO KAS: fix here
       if (!validateSecureUrl(this.kasEndpoint)) {
         throw new ConfigurationError(
           `Invalid KAS endpoint [${this.kasEndpoint}]; to force, please list it among allowedKases`
@@ -445,6 +446,7 @@ export class Client {
         ? maxByteLimit
         : opts.byteLimit;
     const encryptionInformation = new SplitKey(new AesGcmCipher(this.cryptoService));
+    // TODO KAS: check here
     const splits: SplitStep[] = splitPlan?.length
       ? splitPlan
       : [{ kas: opts.defaultKASEndpoint ?? this.kasEndpoint }];
@@ -516,6 +518,8 @@ export class Client {
    * @return a {@link https://nodejs.org/api/stream.html#stream_class_stream_readable|Readable} stream containing the decrypted plaintext.
    * @see DecryptParamsBuilder
    */
+
+  // TODO KAS: fix here
   async decrypt({
     source,
     allowList,
@@ -531,6 +535,7 @@ export class Client {
       throw new ConfigurationError('AuthProvider missing');
     }
     const chunker = await makeChunkable(source);
+    // TODO KAS: fix here for real
     if (!allowList) {
       allowList = this.allowedKases;
     }

--- a/lib/tdf3/src/tdf.ts
+++ b/lib/tdf3/src/tdf.ts
@@ -674,6 +674,7 @@ export async function loadTDFStream(chunker: Chunker): Promise<InspectedTDFOverv
   return { manifest, zipReader, centralDirectory };
 }
 
+/// TODO KAS: fix here?
 export function splitLookupTableFactory(
   keyAccess: KeyAccessObject[],
   allowedKases: OriginAllowList
@@ -991,6 +992,7 @@ export async function readStream(cfg: DecryptConfiguration) {
   return decryptStreamFrom(cfg, overview);
 }
 
+// TODO: fix here
 export async function decryptStreamFrom(
   cfg: DecryptConfiguration,
   { manifest, zipReader, centralDirectory }: InspectedTDFOverview

--- a/lib/tdf3/src/tdf.ts
+++ b/lib/tdf3/src/tdf.ts
@@ -674,7 +674,6 @@ export async function loadTDFStream(chunker: Chunker): Promise<InspectedTDFOverv
   return { manifest, zipReader, centralDirectory };
 }
 
-/// TODO KAS: fix here?
 export function splitLookupTableFactory(
   keyAccess: KeyAccessObject[],
   allowedKases: OriginAllowList
@@ -992,7 +991,13 @@ export async function readStream(cfg: DecryptConfiguration) {
   return decryptStreamFrom(cfg, overview);
 }
 
-// TODO: fix here
+// TODO: potentially might need fixing here
+// By the time this function is called the allow list will be already set.
+// Verify that this function is not exported in the sdk and only exported for internal use
+// Verify this during tests and PR
+// Remove this comment before merging!
+// https://www.youtube.com/watch?v=NGrLb6W5YOM
+// Don't leave me here all by myself!
 export async function decryptStreamFrom(
   cfg: DecryptConfiguration,
   { manifest, zipReader, centralDirectory }: InspectedTDFOverview

--- a/lib/tests/mocha/encrypt-decrypt.spec.ts
+++ b/lib/tests/mocha/encrypt-decrypt.spec.ts
@@ -41,6 +41,7 @@ describe('rewrap error cases', function () {
 
     client = new Client.Client({
       kasEndpoint: kasUrl,
+      allowedKases: [kasUrl],
       dpopKeys: Mocks.entityKeyPair(),
       clientId: 'id',
       authProvider: baseAuthProvider,
@@ -57,6 +58,7 @@ describe('rewrap error cases', function () {
     if (customAuthProvider) {
       client = new Client.Client({
         kasEndpoint: kasUrl,
+        allowedKases: [kasUrl],
         dpopKeys: Mocks.entityKeyPair(),
         clientId: 'id',
         authProvider: customAuthProvider,
@@ -191,6 +193,7 @@ describe('rewrap error cases', function () {
       // Point to a non-existent server
       client = new Client.Client({
         kasEndpoint: 'http://localhost:9999',
+        allowedKases: ['http://localhost:9999'],
         dpopKeys: Mocks.entityKeyPair(),
         clientId: 'id',
         authProvider: {
@@ -273,6 +276,7 @@ describe('encrypt decrypt test', async function () {
         // });
         const client = new Client.Client({
           kasEndpoint: kasUrl,
+          allowedKases: [kasUrl],
           dpopKeys: Mocks.entityKeyPair(),
           clientId: 'id',
           authProvider,

--- a/lib/tests/server.ts
+++ b/lib/tests/server.ts
@@ -373,6 +373,15 @@ const kas: RequestListener = async (req, res) => {
       });
       res.statusCode = 200;
       res.end('Server stopped');
+    } else if (
+      url.pathname === '/policy.kasregistry.KeyAccessServerRegistryService/ListKeyAccessServers'
+    ) {
+      console.log('Listed Key Access Servers!');
+      res.writeHead(200);
+      res.end(
+        JSON.stringify({ keyAccessServers: [{ uri: 'http://localhost:3000' }], pagination: {} })
+      );
+      return;
     } else {
       console.log(`[DEBUG] invalid path [${url.pathname}]`);
       res.statusCode = 404;

--- a/lib/tests/web/nano-roundtrip.test.ts
+++ b/lib/tests/web/nano-roundtrip.test.ts
@@ -16,14 +16,15 @@ const authProvider = <AuthProvider>{
 };
 
 const kasEndpoint = 'http://localhost:3000';
+const platformUrl = 'http://localhost:3000';
 
 describe('Local roundtrip Tests', () => {
   for (const ecdsaBinding of [false, true]) {
     const bindingName = ecdsaBinding ? 'ecdsa' : 'gmac';
     it(`roundtrip string (${bindingName} policy binding)`, async () => {
-      const client = new NanoTDFClient({ authProvider, kasEndpoint });
+      const client = new NanoTDFClient({ authProvider, kasEndpoint, platformUrl });
       const cipherText = await client.encrypt('hello world', { ecdsaBinding });
-      const client2 = new NanoTDFClient({ authProvider, kasEndpoint });
+      const client2 = new NanoTDFClient({ authProvider, kasEndpoint, platformUrl });
       const nanotdfParsed = NanoTDF.from(cipherText);
 
       expect(nanotdfParsed.header.kas.url).to.equal(kasEndpoint);

--- a/lib/tests/web/nanotdf/Client.test.ts
+++ b/lib/tests/web/nanotdf/Client.test.ts
@@ -5,13 +5,14 @@ import Client from '../../../src/nanotdf/Client.js';
 describe('nanotdf client', () => {
   it('Can create a client with a mock EAS', async () => {
     const kasEndpoint = 'https://etheria.local/kas';
+    const platformUrl = 'https://etheria.local';
     const authProvider = await clientAuthProvider({
       clientId: 'string',
       oidcOrigin: 'string',
       exchange: 'client',
       clientSecret: 'password',
     });
-    const client = new Client({ authProvider, kasEndpoint });
+    const client = new Client({ authProvider, kasEndpoint, platformUrl });
     expect(client.authProvider).to.be.ok;
   });
 });

--- a/lib/tests/web/roundtrip.test.ts
+++ b/lib/tests/web/roundtrip.test.ts
@@ -18,6 +18,7 @@ const authProvider = <AuthProvider>{
 };
 
 const kasEndpoint = 'http://localhost:3000';
+const platformUrl = 'http://localhost:3000';
 
 describe('Local roundtrip Tests', () => {
   it(`ztdf roundtrip string`, async () => {
@@ -75,9 +76,9 @@ describe('Local roundtrip Tests', () => {
       expect(new TextDecoder().decode(actual)).to.be.equal('hello world');
     });
     it(`roundtrip string (${bindingType} policy binding, deprecated API)`, async () => {
-      const client = new NanoTDFClient({ authProvider, kasEndpoint });
+      const client = new NanoTDFClient({ authProvider, kasEndpoint, platformUrl });
       const cipherText = await client.encrypt('hello world', { ecdsaBinding });
-      const client2 = new NanoTDFClient({ authProvider, kasEndpoint });
+      const client2 = new NanoTDFClient({ authProvider, kasEndpoint, platformUrl });
       const nanotdfParsed = NanoTDF.from(cipherText);
 
       expect(nanotdfParsed.header.kas.url).to.equal(kasEndpoint);


### PR DESCRIPTION
## Motivation
To avoid malicious KASes, when a file is decrypted we want to give the platform administrators the ability to make sure that that KAS is within the platform's allowed KASes.

For this we will use the gRPC endpoint `/policy.kasregistry.KeyAccessServerRegistryService/ListKeyAccessServers` that will return the list of allowed KAS during decryption process and verify that the requested KAS is within that list.

## PR Changes
- adds `fetchKeyAccessServers()` function to get the allowed kas list
- adds `platformUrl` parameter to the various clients
- adds a safeguard to throw error when neither `platformUrl` nor `allowedKasList` is passed


## Minimizing Impact
The `platformUrl` is changing the clients API signature and is a breaking change. To minimize this breaking change here is the list of the scenarios and in which the consumers might get affected:

**SCENARIO 1**
> When `allowedKASEndpoints` is passed it 

Works out of the box because we don't need to reach out to `/ListKeyAccessServers`.  
The consumer is telling the sdk which are the KASes it allows.
```javascript
 const client = new OpenTDF({
      authProvider: oidcClient,
      defaultReadOptions: {
        allowedKASEndpoints: [c.kas],
      }
    });
```

**SCENARIO 2**
> When `ignoreAllowList` is passed 

Works out of the box because we don't need to reach out to `/ListKeyAccessServers`.
The consumer is telling the sdk to allow all KASes.
```javascript
 const client = new OpenTDF({
      authProvider: oidcClient,
      defaultReadOptions: {
        ignoreAllowList: true,
      }
    });
```

**SCENARIO 3**
> Neither `ignoreAllowList` or `allowedKASEnpoints` is passed. `platfromUrl` is passed

`platfromUrl` parameter is required so that sdk knows how to locate the platform `/ListKeyAccessServers`
The sdk will get the list of allowed KAS from the platform
```javascript
 const client = new OpenTDF({
      platformUrl: 'https://opentdf-platform.com', // <-- BREAKING CHANGE
      authProvider: oidcClient
    });
```

**SCENARIO 4**
> Neither `ignoreAllowList`, `allowedKASEnpoints` nor `platformUrl`  is passed

When calling `decrypt` it will fail with error message 
```
platformUrl is required when allowedKasEndpoints is empty
```

```javascript
 const client = new OpenTDF({
      authProvider: oidcClient
    });
```

**SCENARIO 5**
> When `kasEndpoint` is passed

This currently fails on decrypt because neither `allowList` or `platformUrl` is passed. There is a potential fix we can explore. It should be safe to assume that the `kasEndpoint` is a safe KAS. If the `allowedKasList` is empty, we can add the `kasEndpoint` to that list and the decrypt will work. 

```javascript
 const client = new OpenTDF({
      kasEndpoint: kasUrl,
      authProvider: oidcClient
    });
``` 


## Pending
- [ ] Finish the function `fetchKeyAccessServers` to actually load the KAS list, currently its returning the platformURL
- [ ] Update the tests to account for the new scenarios
- [ ] Add a warning in the console if KAS list is unsafe