### PR TITLE
feat: export connect rpc generated platform from package.json

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -39,9 +39,9 @@
       }
     },
     "node_modules/@bufbuild/protobuf": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.4.0.tgz",
-      "integrity": "sha512-RN9M76x7N11QRihKovEglEjjVCQEA9PRBVnDgk9xw8JHLrcUrp4FpAVSPSH91cNbcTft3u2vpLN4GMbiKY9PJw==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.5.1.tgz",
+      "integrity": "sha512-lut4UTvKL8tqtend0UDu7R79/n9jA7Jtxf77RNPbxtmWqfWI4qQ9bTjf7KCS4vfqLmpQbuHr1ciqJumAgJODdw==",
       "peer": true
     },
     "node_modules/@connectrpc/connect": {
@@ -547,7 +547,7 @@
     "node_modules/@opentdf/sdk": {
       "version": "0.3.2",
       "resolved": "file:../lib/opentdf-sdk-0.3.2.tgz",
-      "integrity": "sha512-puedYalPf/LTsNjVcMRy0O7BdAWXRL0UAIwyJKMUS556XAVnyNfQNvGcJIeaVSVAHOlItgOrOyGlDFb5aUOrKA==",
+      "integrity": "sha512-Zwdso3lsMh0ZMaFCuLqVRbl6IaHHMbGkn0F3NWStxrKJfB+zEPdBboI7PEv5p1lHE/4XA+9laO7Gr70UZJxtzg==",
       "dependencies": {
         "@connectrpc/connect": "^2.0.2",
         "@connectrpc/connect-web": "^2.0.2",

--- a/lib/package.json
+++ b/lib/package.json
@@ -57,6 +57,11 @@
       "types": "./dist/types/src/platform.d.ts",
       "require": "./dist/cjs/src/platform.js",
       "import": "./dist/web/src/platform.js"
+    },
+    "./platform/*": {
+      "types": "./dist/types/src/platform/*",
+      "require": "./dist/cjs/src/platform/*",
+      "import": "./dist/web/src/platform/*"
     }
   },
   "scripts": {

--- a/lib/src/platform.ts
+++ b/lib/src/platform.ts
@@ -1,20 +1,3 @@
-// export client service definitions
-export * as authorization from './platform/authorization/authorization_pb.js';
-export * as common from './platform/common/common_pb.js';
-export * as entityResolution from './platform/entityresolution/entity_resolution_pb.js';
-export * as kas from './platform/kas/kas_pb.js';
-export * as policyActions from './platform/policy/actions/actions_pb.js';
-export * as policyAttributes from './platform/policy/attributes/attributes_pb.js';
-export * as policyKasRegistry from './platform/policy/kasregistry/key_access_server_registry_pb.js';
-export * as policyNamespaces from './platform/policy/namespaces/namespaces_pb.js';
-export * as policyObjects from './platform/policy/objects_pb.js';
-export * as policyRegisteredResources from './platform/policy/registeredresources/registered_resources_pb.js';
-export * as policyResourceMapping from './platform/policy/resourcemapping/resource_mapping_pb.js';
-export * as policySelectors from './platform/policy/selectors_pb.js';
-export * as policySubjectMapping from './platform/policy/subjectmapping/subject_mapping_pb.js';
-export * as policyUnsafe from './platform/policy/unsafe/unsafe_pb.js';
-export * as wellknown from './platform/wellknownconfiguration/wellknown_configuration_pb.js';
-
 // export Connect RPC framework
 export * as platformConnectWeb from '@connectrpc/connect-web';
 export * as platformConnect from '@connectrpc/connect';

--- a/web-app/package-lock.json
+++ b/web-app/package-lock.json
@@ -338,9 +338,9 @@
       }
     },
     "node_modules/@bufbuild/protobuf": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.4.0.tgz",
-      "integrity": "sha512-RN9M76x7N11QRihKovEglEjjVCQEA9PRBVnDgk9xw8JHLrcUrp4FpAVSPSH91cNbcTft3u2vpLN4GMbiKY9PJw==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.5.1.tgz",
+      "integrity": "sha512-lut4UTvKL8tqtend0UDu7R79/n9jA7Jtxf77RNPbxtmWqfWI4qQ9bTjf7KCS4vfqLmpQbuHr1ciqJumAgJODdw==",
       "peer": true
     },
     "node_modules/@connectrpc/connect": {
@@ -1139,7 +1139,7 @@
     "node_modules/@opentdf/sdk": {
       "version": "0.3.2",
       "resolved": "file:../lib/opentdf-sdk-0.3.2.tgz",
-      "integrity": "sha512-puedYalPf/LTsNjVcMRy0O7BdAWXRL0UAIwyJKMUS556XAVnyNfQNvGcJIeaVSVAHOlItgOrOyGlDFb5aUOrKA==",
+      "integrity": "sha512-Zwdso3lsMh0ZMaFCuLqVRbl6IaHHMbGkn0F3NWStxrKJfB+zEPdBboI7PEv5p1lHE/4XA+9laO7Gr70UZJxtzg==",
       "dependencies": {
         "@connectrpc/connect": "^2.0.2",
         "@connectrpc/connect-web": "^2.0.2",

--- a/web-app/src/components/ConnectRpcExample.tsx
+++ b/web-app/src/components/ConnectRpcExample.tsx
@@ -1,5 +1,6 @@
 import { AuthProvider } from '@opentdf/sdk';
 import { PlatformClient } from '@opentdf/sdk/platform';
+import { ActiveStateEnum } from '@opentdf/sdk/platform/common/common_pb.js';
 import { useState } from 'react';
 
 interface ConnectRpcExampleProps {
@@ -25,7 +26,16 @@ export function ConnectRpcExample({ authProvider }: ConnectRpcExampleProps) {
   };
 
   const handlePolicy = async () => {
-    const response = await platform.v1.attributes.listAttributes({});
+    const request = {
+      namespace: 'default',
+      state: ActiveStateEnum.ACTIVE,
+      pagination: {
+        limit: 100,
+        offset: 0,
+      },
+    };
+
+    const response = await platform.v1.attributes.listAttributes(request);
     setResult(response.attributes.map((s) => `${s}`).join(','));
   };
 


### PR DESCRIPTION
**Motivation**
When creating RPC requests, we want to have the ability to define the `type` of the request. Connect RPC generated platform provides those types.
The issue is that typescript named exports do not export the types. Meaning this line  only ends up exporting the values from common. Not the types. 
```js
export * as common from './platform/common/common_pb.js';
```

The types are currently in the build already, just not accessible. This PR makes the types accessible

**PR changes**
Exports everything  from the generated client`/dist/lib/platform*` as `/platform/*` from the package.json. 
This allows for all the types to be accessible

Examples of how a type can be imported now 

```js
import { ActiveStateEnum } from '@opentdf/sdk/platform/common/common_pb.js';
```
