### PR TITLE
feat(sdk): get kas public key from base key in wellknown config

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -39,15 +39,17 @@
       }
     },
     "node_modules/@bufbuild/protobuf": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.5.1.tgz",
-      "integrity": "sha512-lut4UTvKL8tqtend0UDu7R79/n9jA7Jtxf77RNPbxtmWqfWI4qQ9bTjf7KCS4vfqLmpQbuHr1ciqJumAgJODdw==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.5.2.tgz",
+      "integrity": "sha512-foZ7qr0IsUBjzWIq+SuBLfdQCpJ1j8cTuNNT4owngTHoN5KsJb8L9t65fzz7SCeSWzescoOil/0ldqiL041ABg==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)",
       "peer": true
     },
     "node_modules/@connectrpc/connect": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.0.2.tgz",
       "integrity": "sha512-xZuylIUNvNlH52e/4eQsZvY4QZyDJRtEFEDnn/yBrv5Xi5ZZI/p8X+GAHH35ucVaBvv9u7OzHZo8+tEh1EFTxA==",
+      "license": "Apache-2.0",
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.2.0"
       }
@@ -56,6 +58,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@connectrpc/connect-web/-/connect-web-2.0.2.tgz",
       "integrity": "sha512-QANMFPiL2o66BdBEctg4TsQLe5ozsBLqcle3dCBp7BwGlNGTY6NnNnqmt+YRnpeMW88GgomJwWNMGCrRD9pRKA==",
+      "license": "Apache-2.0",
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.2.0",
         "@connectrpc/connect": "2.0.2"
@@ -547,7 +550,8 @@
     "node_modules/@opentdf/sdk": {
       "version": "0.3.2",
       "resolved": "file:../lib/opentdf-sdk-0.3.2.tgz",
-      "integrity": "sha512-Zwdso3lsMh0ZMaFCuLqVRbl6IaHHMbGkn0F3NWStxrKJfB+zEPdBboI7PEv5p1lHE/4XA+9laO7Gr70UZJxtzg==",
+      "integrity": "sha512-KH9fhhwUe3lhO82I0yn2HzXW6GFYR1tZR6Wx247gPChEUGecb3+3ENM7DS3ZtRrz2EdZX945y8/1vO1xM/1FDg==",
+      "license": "BSD-3-Clause-Clear",
       "dependencies": {
         "@connectrpc/connect": "^2.0.2",
         "@connectrpc/connect-web": "^2.0.2",
@@ -1110,6 +1114,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
       "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
+      "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
       }
@@ -1338,6 +1343,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/dpop/-/dpop-1.4.1.tgz",
       "integrity": "sha512-+Cus+OlLk9uFWbPZX/RsLpMviYAmyJpJpooto2NDQ0lnk0/S2TblPunC4nVtETOxCIsXvu4YILIOPC7LIHHXIg==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -2071,6 +2077,7 @@
       "version": "6.0.11",
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.0.11.tgz",
       "integrity": "sha512-QxG7EaliDARm1O1S8BGakqncGT9s25bKL1WSf6/oa17Tkqwi8D2ZNglqCF+DsYF88/rV66Q/Q2mFAy697E1DUg==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -2096,9 +2103,10 @@
       "peer": true
     },
     "node_modules/json-canonicalize": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/json-canonicalize/-/json-canonicalize-1.0.6.tgz",
-      "integrity": "sha512-kP2iYpOS5SZHYhIaR1t9oG80d4uTY3jPoaBj+nimy3njtJk8+sRsVatN8pyJRDRtk9Su3+6XqA2U8k0dByJBUQ=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/json-canonicalize/-/json-canonicalize-1.1.0.tgz",
+      "integrity": "sha512-Y/gUYcjKpyl5aB2ksljGQFNmnL2tnlirHNTwkk+rzIjDOsQkqnHHbbWXMsP7OmKpmC2pWN2j+CqWnM2/ShvxcQ==",
+      "license": "MIT"
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "3.0.2",
@@ -3221,6 +3229,7 @@
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
+      "license": "MIT",
       "bin": {
         "uuid": "dist/esm/bin/uuid"
       }

--- a/lib/src/access/access-rpc.ts
+++ b/lib/src/access/access-rpc.ts
@@ -1,4 +1,5 @@
 import {
+  isPublicKeyAlgorithm,
   KasPublicKeyAlgorithm,
   KasPublicKeyInfo,
   noteInvalidPublicKey,
@@ -74,6 +75,31 @@ export async function fetchKeyAccessServers(
   return new OriginAllowList(serverUrls, false);
 }
 
+interface PlatformBaseKey {
+  kas_id?: string;
+  kas_uri: string;
+  public_key: {
+    algorithm: KasPublicKeyAlgorithm;
+    kid: string;
+    pem: string;
+  };
+}
+
+function isBaseKey(baseKey?: unknown): baseKey is PlatformBaseKey {
+  if (!baseKey) {
+    return false;
+  }
+  const bk = baseKey as PlatformBaseKey;
+  return (
+    !!bk.kas_uri &&
+    !!bk.public_key &&
+    typeof bk.public_key === 'object' &&
+    !!bk.public_key.pem &&
+    !!bk.public_key.algorithm &&
+    isPublicKeyAlgorithm(bk.public_key.algorithm)
+  );
+}
+
 export async function fetchKasPubKey(
   kasEndpoint: string,
   algorithm?: KasPublicKeyAlgorithm
@@ -99,6 +125,48 @@ export async function fetchKasPubKey(
       url: kasEndpoint,
       algorithm: algorithm || 'rsa:2048',
       ...(kid && { kid }),
+    };
+    return result;
+  } catch (e) {
+    throw new NetworkError(`[${platformUrl}] [PublicKey] ${extractRpcErrorMessage(e)}`);
+  }
+}
+
+/**
+ * Fetch the base public key from WellKnownConfiguration of the platform.
+ * @param kasEndpoint The KAS endpoint URL.
+ * @throws {ConfigurationError} If the KAS endpoint is not defined.
+ * @throws {NetworkError} If there is an error fetching the public key from the KAS endpoint.
+ * @returns The base public key information for the KAS endpoint.
+ */
+export async function fetchKasBasePubKey(kasEndpoint: string): Promise<KasPublicKeyInfo> {
+  if (!kasEndpoint) {
+    throw new ConfigurationError('KAS definition not found');
+  }
+  validateSecureUrl(kasEndpoint);
+
+  const platformUrl = getPlatformUrlFromKasEndpoint(kasEndpoint);
+  const platform = new PlatformClient({
+    platformUrl,
+  });
+  try {
+    const { configuration } = await platform.v1.wellknown.getWellKnownConfiguration({});
+    const baseKey = configuration?.base_key as unknown as PlatformBaseKey;
+    if (!isBaseKey(baseKey)) {
+      throw new NetworkError(
+        `Invalid Platform Configuration: [${kasEndpoint}] is missing BaseKey in WellKnownConfiguration`
+      );
+    }
+
+    const result: KasPublicKeyInfo = {
+      key: noteInvalidPublicKey(
+        new URL(baseKey.kas_uri),
+        pemToCryptoPublicKey(baseKey.public_key.pem)
+      ),
+      publicKey: baseKey.public_key.pem,
+      url: baseKey.kas_uri,
+      algorithm: baseKey.public_key.algorithm,
+      kid: baseKey.public_key.kid,
     };
     return result;
   } catch (e) {

--- a/lib/src/opentdf.ts
+++ b/lib/src/opentdf.ts
@@ -335,7 +335,7 @@ export class OpenTDF {
     this.tdf3Client = new TDF3Client({
       authProvider,
       dpopKeys,
-      kasEndpoint: 'https://disallow.all.invalid',
+      kasEndpoint: this.platformUrl || 'https://disallow.all.invalid',
       policyEndpoint,
     });
     this.dpopKeys =
@@ -522,14 +522,17 @@ class NanoTDFReader {
       r.header = nanotdf.header;
       return r;
     }
+    const platformUrl = this.opts.platformUrl || this.outer.platformUrl;
+    const kasEndpoint =
+      this.opts.allowedKASEndpoints?.[0] || platformUrl || 'https://disallow.all.invalid';
     const nc = new Client({
       allowedKases: this.opts.allowedKASEndpoints,
       authProvider: this.outer.authProvider,
       ignoreAllowList: this.opts.ignoreAllowlist,
       dpopEnabled: this.outer.dpopEnabled,
       dpopKeys: this.outer.dpopKeys,
-      kasEndpoint: this.opts.allowedKASEndpoints?.[0] || 'https://disallow.all.invalid',
-      platformUrl: this.opts.platformUrl || this.outer.platformUrl,
+      kasEndpoint,
+      platformUrl,
     });
     // TODO: The version number should be fetched from the API
     const version = '0.0.1';
@@ -691,9 +694,12 @@ class Collection {
         break;
     }
 
+    const kasEndpoint =
+      opts.defaultKASEndpoint || opts.platformUrl || 'https://disallow.all.invalid';
+
     this.client = new NanoTDFDatasetClient({
       authProvider,
-      kasEndpoint: opts.defaultKASEndpoint ?? 'https://disallow.all.invalid',
+      kasEndpoint: kasEndpoint,
       maxKeyIterations: opts.maxKeyIterations,
       platformUrl: opts.platformUrl,
     });

--- a/lib/tdf3/src/client/index.ts
+++ b/lib/tdf3/src/client/index.ts
@@ -398,7 +398,7 @@ export class Client {
       keyMiddleware = defaultKeyMiddleware,
       streamMiddleware = async (stream: DecoratedReadableStream) => stream,
       tdfSpecVersion,
-      wrappingKeyAlgorithm = 'rsa:2048',
+      wrappingKeyAlgorithm,
     } = opts;
     const scope = opts.scope ?? { attributes: [], dissem: [] };
 
@@ -462,7 +462,6 @@ export class Client {
         ? maxByteLimit
         : opts.byteLimit;
     const encryptionInformation = new SplitKey(new AesGcmCipher(this.cryptoService));
-    // TODO KAS: check here
     const splits: SplitStep[] = splitPlan?.length
       ? splitPlan
       : [{ kas: opts.defaultKASEndpoint ?? this.kasEndpoint }];

--- a/lib/tdf3/src/tdf.ts
+++ b/lib/tdf3/src/tdf.ts
@@ -199,7 +199,7 @@ export async function fetchKasPublicKey(
   kas: string,
   algorithm?: KasPublicKeyAlgorithm
 ): Promise<KasPublicKeyInfo> {
-  return fetchKasPubKeyV2(kas, algorithm || 'rsa:2048');
+  return fetchKasPubKeyV2(kas, algorithm);
 }
 
 export async function extractPemFromKeyString(

--- a/lib/tests/mocha/unit/tdf.spec.ts
+++ b/lib/tests/mocha/unit/tdf.spec.ts
@@ -91,7 +91,7 @@ describe('fetchKasPublicKey', async () => {
   it('localhost kas is valid', async () => {
     const pk2 = await TDF.fetchKasPublicKey('http://localhost:3000');
     expect(pk2.publicKey).to.include('BEGIN CERTIFICATE');
-    expect(pk2.kid).to.equal('r1');
+    expect(pk2.kid).to.equal('e1');
   });
 
   it('invalid algorithms', async () => {
@@ -100,9 +100,14 @@ describe('fetchKasPublicKey', async () => {
       console.log(res);
       expect.fail('did not throw');
     } catch (e) {
-      // TODO RPC: check why error thrown is failed to fetch
       expect(!!e).to.equal(true);
     }
+  });
+
+  it('localhost BaseKey', async () => {
+    const pk2 = await TDF.fetchKasPublicKey('http://localhost:3000');
+    expect(pk2.publicKey).to.include('BEGIN CERTIFICATE');
+    expect(pk2.kid).to.equal('e1');
   });
 });
 

--- a/lib/tests/server.ts
+++ b/lib/tests/server.ts
@@ -421,7 +421,21 @@ const kas: RequestListener = async (req, res) => {
     ) {
       res.statusCode = 200;
       res.setHeader('Content-Type', 'application/json');
-      res.end(JSON.stringify({ health: { endpoint: '/healthz' } }));
+      res.end(
+        JSON.stringify({
+          configuration: {
+            base_key: {
+              kas_id: '34f2acdc-3d9c-4e92-80b6-90fe4dc9afcb',
+              kas_uri: 'http://localhost:3000',
+              public_key: {
+                algorithm: 'ec:secp256r1',
+                kid: 'e1',
+                pem: Mocks.kasECCert,
+              },
+            },
+          },
+        })
+      );
       return;
     } else if (url.pathname === '/policy.attributes.AttributesService/ListAttributes') {
       const token = req.headers['authorization'] as string;

--- a/web-app/package-lock.json
+++ b/web-app/package-lock.json
@@ -338,15 +338,17 @@
       }
     },
     "node_modules/@bufbuild/protobuf": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.5.1.tgz",
-      "integrity": "sha512-lut4UTvKL8tqtend0UDu7R79/n9jA7Jtxf77RNPbxtmWqfWI4qQ9bTjf7KCS4vfqLmpQbuHr1ciqJumAgJODdw==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.5.2.tgz",
+      "integrity": "sha512-foZ7qr0IsUBjzWIq+SuBLfdQCpJ1j8cTuNNT4owngTHoN5KsJb8L9t65fzz7SCeSWzescoOil/0ldqiL041ABg==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)",
       "peer": true
     },
     "node_modules/@connectrpc/connect": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.0.2.tgz",
       "integrity": "sha512-xZuylIUNvNlH52e/4eQsZvY4QZyDJRtEFEDnn/yBrv5Xi5ZZI/p8X+GAHH35ucVaBvv9u7OzHZo8+tEh1EFTxA==",
+      "license": "Apache-2.0",
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.2.0"
       }
@@ -355,6 +357,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@connectrpc/connect-web/-/connect-web-2.0.2.tgz",
       "integrity": "sha512-QANMFPiL2o66BdBEctg4TsQLe5ozsBLqcle3dCBp7BwGlNGTY6NnNnqmt+YRnpeMW88GgomJwWNMGCrRD9pRKA==",
+      "license": "Apache-2.0",
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.2.0",
         "@connectrpc/connect": "2.0.2"
@@ -1139,7 +1142,8 @@
     "node_modules/@opentdf/sdk": {
       "version": "0.3.2",
       "resolved": "file:../lib/opentdf-sdk-0.3.2.tgz",
-      "integrity": "sha512-Zwdso3lsMh0ZMaFCuLqVRbl6IaHHMbGkn0F3NWStxrKJfB+zEPdBboI7PEv5p1lHE/4XA+9laO7Gr70UZJxtzg==",
+      "integrity": "sha512-KH9fhhwUe3lhO82I0yn2HzXW6GFYR1tZR6Wx247gPChEUGecb3+3ENM7DS3ZtRrz2EdZX945y8/1vO1xM/1FDg==",
+      "license": "BSD-3-Clause-Clear",
       "dependencies": {
         "@connectrpc/connect": "^2.0.2",
         "@connectrpc/connect-web": "^2.0.2",
@@ -2211,6 +2215,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
       "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
+      "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
       }
@@ -2405,6 +2410,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/dpop/-/dpop-1.4.1.tgz",
       "integrity": "sha512-+Cus+OlLk9uFWbPZX/RsLpMviYAmyJpJpooto2NDQ0lnk0/S2TblPunC4nVtETOxCIsXvu4YILIOPC7LIHHXIg==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -3191,6 +3197,7 @@
       "version": "6.0.11",
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.0.11.tgz",
       "integrity": "sha512-QxG7EaliDARm1O1S8BGakqncGT9s25bKL1WSf6/oa17Tkqwi8D2ZNglqCF+DsYF88/rV66Q/Q2mFAy697E1DUg==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -3237,9 +3244,10 @@
       "peer": true
     },
     "node_modules/json-canonicalize": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/json-canonicalize/-/json-canonicalize-1.0.6.tgz",
-      "integrity": "sha512-kP2iYpOS5SZHYhIaR1t9oG80d4uTY3jPoaBj+nimy3njtJk8+sRsVatN8pyJRDRtk9Su3+6XqA2U8k0dByJBUQ=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/json-canonicalize/-/json-canonicalize-1.1.0.tgz",
+      "integrity": "sha512-Y/gUYcjKpyl5aB2ksljGQFNmnL2tnlirHNTwkk+rzIjDOsQkqnHHbbWXMsP7OmKpmC2pWN2j+CqWnM2/ShvxcQ==",
+      "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -4692,6 +4700,7 @@
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
+      "license": "MIT",
       "bin": {
         "uuid": "dist/esm/bin/uuid"
       }


### PR DESCRIPTION
**Motivation**
We want to ensures the Web SDK securely and consistently uses the "Base Key" from the WellKnown endpoint for cryptographic operations, provides a fallback when other keys are missing. 

--- 

**PR Changes**
- updates fetchPublicKey to read the Public Key from BaseKey in the Wellknown Configuration  and fallback to PublicKey
- Added integration tests to cover new functionality

---

**Use BaseKey flow**


**Scenario ZTDF **
 ztdf encrypt reaches out to WellKnown to get public key
- Base Key is RSA: encryption succeeds
- Base Key is ECC: encryption succeeds
- Base Key not set: encryption succeeds with PublicKey fallback

**Scenario Nano**
 nano encrypt reaches out to WellKnown to get public key.
- Base Key is RSA: encryption fails
- Base Key is ECC: encryption succeeds
- Base key not set: encryption succeeds with PublicKey fallback
---

**Example**
Here is an example of instantiating the client to use the base key feature
```ts
 const client = new OpenTDF({
      authProvider: oidcClient,
      platformUrl: `http://localhost:8080`
    });
```