### PR TITLE
chore: make source optional in collection

### DIFF
--- a/lib/src/opentdf.ts
+++ b/lib/src/opentdf.ts
@@ -100,6 +100,8 @@ export type CreateNanoTDFCollectionOptions = CreateNanoTDFOptions & {
   platformUrl: string;
   /** The maximum number of key iterations to use for a single DEK. */
   maxKeyIterations?: number;
+  /** Optional source. TODO: check if it can be removed from create options  */
+  source?: Source;
 };
 
 /** Metadata for a TDF object. */


### PR DESCRIPTION
**Motivation**
When creating a collection a `source` is required but  for collection that does not make sense. In the collection the source is passed on the `.encrypt()` method

```
const collection = await opentdf.createNanoTDFCollection({
      platformUrl,
      // TODO: source is marked as required, but we don't need it here
      source: {} as never,
    });

    const stream = await collection.encrypt({
      type: "buffer",
      location: new TextEncoder().encode(inputText),
    });

    const encrypted = await new Response(stream).bytes();
```

**PR Changes**
- make source optional
- add TODO to verify if it can be removed directly instead of just making it optional

**Note**
The overide won't work, we need to modify the parent type (which we might not want to do)