### PR TITLE
chore: Add dependency-review workflow that always targets `main`

### DIFF
--- a/.github/workflows/main-dependency-review.yaml
+++ b/.github/workflows/main-dependency-review.yaml
@@ -1,0 +1,14 @@
+name: 'Main Branch Dependency Review'
+on:
+  pull_request: {}
+
+jobs:
+  main-dependency-review:
+    permissions:
+      contents: read
+      pull-requests: write
+
+    uses: ./.github/workflows/dependency-review.yaml
+    with:
+      base-ref: main
+      fail-on-severity: low


### PR DESCRIPTION
The `base-ref` for dependency review is typically the target branch you're merging into. This results in dependency-review alerting on any changed dependencies which may have CVE's.

By using `orign/main` as our `base-ref`, we are now also validating that the target branch has adopted all necessary security updates that were adopted within the `main` branch.

This will help ensure `release` branches have adopted all necessary security fixes.