### PR TITLE
chore: DSPX-1665 add link to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This project is focused on providing web client support for the OpenTDF platform
 This includes encrypting and decrypting TDF content,
 and some management tasks for ABAC.
 
+**[OpenTDF Web Documentation](https://opentdf.github.io/web-sdk/)**
+
 ## Usage (NanoTDF)
 
 ```typescript


### PR DESCRIPTION
**Motivation**
We want to provide great documentation for OpenTDF. Currently we have WebSDK documentation automatically generated via TypeDoc and hosted  [here](https://opentdf.github.io/web-sdk/) but they are not linked in the readme and hard to discover

**PR Changes**
- Adds a link to the typedoc docs in the readme.md