### PR TITLE
chore(ci): SRE-5791 Update workflows to use OIDC

### DIFF
--- a/.github/workflows/deliver.yaml
+++ b/.github/workflows/deliver.yaml
@@ -17,6 +17,5 @@ jobs:
     permissions:
       contents: write
       packages: write
+      id-token: write
     uses: opentdf/web-sdk/.github/workflows/reusable_deliver.yaml@main
-    secrets:
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/reusable_deliver.yaml
+++ b/.github/workflows/reusable_deliver.yaml
@@ -2,10 +2,7 @@ name: "Reusable worflow: Deliver Client to npm registry"
 
 on:
   workflow_call:
-    secrets:
-      NPM_TOKEN:
-        required: true
-
+    #
 # Default empty permissions for all jobs
 permissions: {}
 
@@ -80,6 +77,7 @@ jobs:
   deliver-npmjs:
     permissions:
       contents: read
+      id-token: write # needed for OIDC access
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout repo"
@@ -110,7 +108,6 @@ jobs:
         env:
           DIST_TAG: ${{ steps.guess-build-metadata.outputs.DIST_TAG }}
           FULL_VERSION: ${{ steps.guess-build-metadata.outputs.FULL_VERSION }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           bash scripts/deliver-to-npm-registry.sh "$FULL_VERSION" "$DIST_TAG"
 


### PR DESCRIPTION
NPM now expires tokens quickly. Using OIDC gives us longer and more secure
authentication windows for publishing
https://github.blog/changelog/2025-09-29-strengthening-npm-security-important-changes-to-authentication-and-token-management/
