### PR TITLE
feat(ci): add npm provenance support for package publishing

### DIFF
--- a/.github/workflows/reusable_deliver.yaml
+++ b/.github/workflows/reusable_deliver.yaml
@@ -108,6 +108,7 @@ jobs:
         env:
           DIST_TAG: ${{ steps.guess-build-metadata.outputs.DIST_TAG }}
           FULL_VERSION: ${{ steps.guess-build-metadata.outputs.FULL_VERSION }}
+          NPM_PROVENANCE: "true"
         run: |
           bash scripts/deliver-to-npm-registry.sh "$FULL_VERSION" "$DIST_TAG"
 

--- a/scripts/deliver-to-npm-registry.sh
+++ b/scripts/deliver-to-npm-registry.sh
@@ -6,6 +6,12 @@ set -exuo pipefail
 version="${1%%+*}"
 tag="${2}"
 
+# Build provenance flag if NPM_PROVENANCE is set to "true"
+provenance_flag=""
+if [[ "${NPM_PROVENANCE:-}" == "true" ]]; then
+  provenance_flag="--provenance"
+fi
+
 cd lib
 file=src/version.ts
 if ! sed "s|export const version = \'[^']\{1,\}\'; // x-release-please-version\$|export const version = \'${version}\';|" "${file}" >"${file}.tmp"; then
@@ -15,7 +21,7 @@ fi
 mv "${file}.tmp" "${file}"
 
 npm version --no-git-tag-version --allow-same-version "$version"
-npm publish --access public --tag "$tag"
+npm publish --access public --tag "$tag" $provenance_flag
 
 # Wait for npm publish to go through...
 sleep 5
@@ -24,7 +30,7 @@ cd "../cli"
 npm version --no-git-tag-version --allow-same-version "$version"
 npm uninstall "@opentdf/sdk"
 npm install "@opentdf/sdk@$version"
-npm publish --access public --tag "$tag"
+npm publish --access public --tag "$tag" $provenance_flag
 
 if [[ "$GITHUB_STEP_SUMMARY" ]]; then
 	echo "### Published ${version} (${tag})" >>"$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Adds npm provenance support to enable supply chain security through package attestation
when publishing to the npm registry.

## Changes

- Add `NPM_PROVENANCE` environment variable to `reusable_deliver.yaml` workflow
- Update `deliver-to-npm-registry.sh` to conditionally include `--provenance` flag
- Both SDK and CLI packages will be published with provenance when enabled

## Why

NPM provenance provides a verifiable link between a published package and its source
repository, enhancing supply chain security. This works in conjunction with the OIDC
authentication added in #796.