### PR TITLE
chore(ci): SRE-5791 Unset token when using provenence

### DIFF
--- a/scripts/deliver-to-npm-registry.sh
+++ b/scripts/deliver-to-npm-registry.sh
@@ -8,8 +8,10 @@ tag="${2}"
 
 # Build provenance flag if NPM_PROVENANCE is set to "true"
 provenance_flag=""
+use_oidc=0
 if [[ "${NPM_PROVENANCE:-}" == "true" ]]; then
   provenance_flag="--provenance"
+  unset NODE_AUTH_TOKEN # This is needed to force OIDC, as the setup-node action sets NODE_AUTH_TOKEN https://github.com/actions/setup-node/issues/1440
 fi
 
 cd lib


### PR DESCRIPTION
When using the setup-node action, the `NODE_AUTH_TOKEN` is automatically configured and this
forces `npm` to try and use it. If we unset the variable, this allows OIDC to be used
