### PR TITLE
fix(ci): update tests to cover sdk-v* tag format for npm latest dist-tag

### DIFF
--- a/.github/workflows/gh-semver.bats
+++ b/.github/workflows/gh-semver.bats
@@ -20,7 +20,16 @@
 }
 
 
-@test "sdk/v prefixed tags go to release" {
+@test "sdk-v prefixed tags go to release" {
+  export GITHUB_REF=refs/tags/sdk-v12
+  export MMP_VER=0.0.1
+  export GITHUB_RUN_NUMBER=1234
+  run $BATS_TEST_DIRNAME/gh-semver.sh
+  echo output=[$output]
+  [[ $output == "0.0.1" ]]
+}
+
+@test "legacy sdk/v prefixed tags go to release" {
   export GITHUB_REF=refs/tags/sdk/v12
   export MMP_VER=0.0.1
   export GITHUB_RUN_NUMBER=1234

--- a/.github/workflows/gh-semver.sh
+++ b/.github/workflows/gh-semver.sh
@@ -29,7 +29,7 @@
 # Tags go to release:
 # ```
 #    package.version = 1.2.3
-#    tag = sdk/v1.2.3
+#    tag = sdk-v1.2.3
 #    workflow run = 256
 #    git SHA = decaf
 #    ----

--- a/.github/workflows/guess-dist-tag.bats
+++ b/.github/workflows/guess-dist-tag.bats
@@ -28,7 +28,14 @@
   [[ $output == "rc" ]]
 }
 
-@test "all tags go to release" {
+@test "sdk-v prefixed tags go to release" {
+  export GITHUB_REF=refs/tags/sdk-v12
+  run $BATS_TEST_DIRNAME/guess-dist-tag.sh
+  echo output=[$output]
+  [[ $output == "latest" ]]
+}
+
+@test "legacy sdk/v prefixed tags go to release" {
   export GITHUB_REF=refs/tags/sdk/v12
   run $BATS_TEST_DIRNAME/guess-dist-tag.sh
   echo output=[$output]


### PR DESCRIPTION
## Summary

- Added test coverage for the `sdk-v*` tag format in `guess-dist-tag.bats` and `gh-semver.bats` (the scripts already handle both `sdk/v*` and `sdk-v*`, but tests only covered the old format)
- Updated the comment in `gh-semver.sh` to reflect the current `sdk-v*` tag format
- Kept existing `sdk/v*` tests as "legacy" to ensure backward compatibility

## Context

Release Please changed the tag format from `sdk/v*` (slash) to `sdk-v*` (hyphen) starting at v0.4.1 (July 2025). The delivery scripts already match both patterns, but tests only validated the old format. npm's `latest` dist-tag has been stuck at 0.4.0 for ~9 months as a result of earlier issues with this mismatch.

## Test plan

- [x] All 11 bats tests pass locally (`bats .github/workflows/guess-dist-tag.bats .github/workflows/gh-semver.bats`)
- [x] `GITHUB_REF=refs/tags/sdk-v0.11.0 .github/workflows/guess-dist-tag.sh` outputs `latest`
- [ ] After merge, merge PR #864 (pending 0.11.0 release) to trigger the fixed publish pipeline and verify `latest` dist-tag updates on npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)