### PR TITLE
fix(sdk): gate signingKey check on dpopEnabled in withCreds

### DIFF
--- a/lib/src/auth/oidc.ts
+++ b/lib/src/auth/oidc.ts
@@ -302,13 +302,13 @@ export class AccessToken {
   }
 
   async withCreds(httpReq: HttpRequest): Promise<HttpRequest> {
+    if (this.config.dpopEnabled && !this.signingKey) {
+      throw new ConfigurationError(
+        'Client public key was not set via `updateClientPublicKey` or passed in via constructor; required when DPoP is enabled'
+      );
+    }
     const accessToken = (this.currentAccessToken ??= await this.get());
-    if (this.config.dpopEnabled) {
-      if (!this.signingKey) {
-        throw new ConfigurationError(
-          'Client public key was not set via `updateClientPublicKey` or passed in via constructor; required when DPoP is enabled'
-        );
-      }
+    if (this.config.dpopEnabled && this.signingKey) {
       const dpopToken = await dpopFn(
         this.signingKey,
         this.cryptoService,

--- a/lib/src/auth/oidc.ts
+++ b/lib/src/auth/oidc.ts
@@ -11,7 +11,7 @@ import { type CryptoService, type KeyPair } from '../../tdf3/src/crypto/declarat
 export type CommonCredentials = {
   /** The OIDC client ID used for token issuance and exchange flows */
   clientId: string;
-  /** The endpoint of the OIDC IdP to authenticate against, ex. 'https://virtru.com/auth' */
+  /** The endpoint of the OIDC IdP to authenticate against, ex. 'https://keycloak.opentdf.local/auth' */
   oidcOrigin: string;
   oidcTokenEndpoint?: string;
   oidcUserInfoEndpoint?: string;

--- a/lib/src/auth/oidc.ts
+++ b/lib/src/auth/oidc.ts
@@ -176,6 +176,8 @@ export class AccessToken {
       }
       // Export opaque public key to PEM format for header
       const publicKeyPem = await this.cryptoService.exportPublicKeyPem(this.signingKey.publicKey);
+      // TODO: Rename to X-OpenTDF-PubKey; requires coordinated change with
+      // platform Keycloak mapper (lib/fixtures/keycloak.go `client.publickey`).
       headers['X-VirtruPubKey'] = base64.encode(publicKeyPem);
       headers.DPoP = await dpopFn(this.signingKey, this.cryptoService, url, 'POST');
     }
@@ -300,13 +302,13 @@ export class AccessToken {
   }
 
   async withCreds(httpReq: HttpRequest): Promise<HttpRequest> {
-    if (!this.signingKey) {
-      throw new ConfigurationError(
-        'Client public key was not set via `updateClientPublicKey` or passed in via constructor, cannot fetch OIDC token with valid Virtru claims'
-      );
-    }
     const accessToken = (this.currentAccessToken ??= await this.get());
-    if (this.config.dpopEnabled && this.signingKey) {
+    if (this.config.dpopEnabled) {
+      if (!this.signingKey) {
+        throw new ConfigurationError(
+          'Client public key was not set via `updateClientPublicKey` or passed in via constructor; required when DPoP is enabled'
+        );
+      }
       const dpopToken = await dpopFn(
         this.signingKey,
         this.cryptoService,

--- a/lib/tests/web/auth/auth.test.ts
+++ b/lib/tests/web/auth/auth.test.ts
@@ -338,4 +338,56 @@ describe('AccessToken', () => {
       expect(mf.callCount).to.eql(2);
     });
   });
+
+  describe('withCreds', () => {
+    it('returns Bearer token without signingKey when DPoP is disabled', async () => {
+      const mf = mockFetch({ access_token: 'test_token' });
+      const accessToken = new AccessToken(
+        {
+          exchange: 'refresh',
+          oidcOrigin: 'https://auth.invalid/auth/realms/test/',
+          clientId: 'myid',
+          refreshToken: 'refresh',
+          dpopEnabled: false,
+        },
+        DefaultCryptoService,
+        mf
+      );
+      const result = await accessToken.withCreds({
+        url: 'https://kas.invalid/v2/rewrap',
+        method: 'POST',
+        headers: {},
+      });
+      expect(result.headers).to.have.property('Authorization', 'Bearer test_token');
+      expect(result.headers).not.to.have.property('DPoP');
+    });
+
+    it('throws when DPoP is enabled but signingKey is missing', async () => {
+      const mf = mockFetch({ access_token: 'test_token' });
+      const accessToken = new AccessToken(
+        {
+          exchange: 'refresh',
+          oidcOrigin: 'https://auth.invalid/auth/realms/test/',
+          clientId: 'myid',
+          refreshToken: 'refresh',
+          dpopEnabled: true,
+        },
+        DefaultCryptoService,
+        mf
+      );
+      // Pre-populate access token so withCreds reaches its own signingKey check
+      // rather than failing in doPost() during token fetch.
+      accessToken.currentAccessToken = 'pre_cached_token';
+      try {
+        await accessToken.withCreds({
+          url: 'https://kas.invalid/v2/rewrap',
+          method: 'POST',
+          headers: {},
+        });
+        assert.fail('Expected ConfigurationError');
+      } catch (e) {
+        expect(e.message).to.match(/required when DPoP is enabled/);
+      }
+    });
+  });
 });

--- a/lib/tests/web/auth/auth.test.ts
+++ b/lib/tests/web/auth/auth.test.ts
@@ -375,9 +375,6 @@ describe('AccessToken', () => {
         DefaultCryptoService,
         mf
       );
-      // Pre-populate access token so withCreds reaches its own signingKey check
-      // rather than failing in doPost() during token fetch.
-      accessToken.currentAccessToken = 'pre_cached_token';
       try {
         await accessToken.withCreds({
           url: 'https://kas.invalid/v2/rewrap',


### PR DESCRIPTION
## Summary

- `withCreds()` unconditionally required `signingKey`, causing non-DPoP auth flows to throw `ConfigurationError` even when DPoP was disabled
- Moved the `signingKey` check inside the `dpopEnabled` branch, matching the existing pattern in `doPost()` and `info()`
- Updated the error message to clarify that `signingKey` is only required when DPoP is enabled (previously referenced "Virtru claims")
- Added TODO for `X-VirtruPubKey` header rename (requires coordinated cross-repo change with platform Keycloak mapper)

## Test plan

- [x] New test: `withCreds` returns Bearer token without `signingKey` when DPoP is disabled
- [x] New test: `withCreds` throws `ConfigurationError` when DPoP is enabled but `signingKey` is missing
- [x] All existing auth tests pass
- [x] 10 pre-existing failures are unrelated (require running platform server)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Token acquisition no longer requires signing keys when DPoP is disabled; configuration errors now occur only if DPoP is enabled but signing credentials are missing.
  * Clarified error messaging for missing DPoP signing credentials.

* **Documentation**
  * Updated OIDC origin example to use the Keycloak host used in local examples.

* **Tests**
  * Added tests covering credential handling with and without DPoP enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->