### PR TITLE
feat(sdk): deprecate AuthProvider in favor of Interceptor pattern

### DIFF
--- a/lib/README.md
+++ b/lib/README.md
@@ -4,19 +4,15 @@ This project presents client code to write and read OpenTDF data formats.
 
 ## Usage
 
-```typescript
-import { AuthProviders, OpenTDF } from '@opentdf/sdk';
+### With Interceptors (Recommended)
 
-// Use refreshAuthProvider for browser applications.
-// The refresh token is obtained after the user logs in via your OIDC provider.
-const authProvider = await AuthProviders.refreshAuthProvider({
-  clientId: 'my-client-id',
-  refreshToken: refreshToken,
-  oidcOrigin: 'https://keycloak.example.com/auth/realms/my-realm',
-});
+Use interceptors to provide authentication. The SDK does not manage tokens — you bring your own auth.
+
+```typescript
+import { authTokenInterceptor, OpenTDF } from '@opentdf/sdk';
 
 const client = new OpenTDF({
-  authProvider,
+  interceptors: [authTokenInterceptor(() => myAuth.getAccessToken())],
   platformUrl: 'https://platform.example.com',
 });
 
@@ -32,4 +28,58 @@ const plainText = await client.read({
   source: { type: 'buffer', location: encrypted },
 });
 console.log(await new Response(plainText).text()); // "hello, world"
+```
+
+The `authTokenInterceptor` takes a function that returns an access token. Your auth library handles token refresh, caching, etc.
+
+For DPoP-bound tokens, use `authTokenDPoPInterceptor`:
+
+```typescript
+import { authTokenDPoPInterceptor, OpenTDF } from '@opentdf/sdk';
+
+const dpopInterceptor = authTokenDPoPInterceptor({
+  tokenProvider: () => myAuth.getAccessToken(),
+});
+
+const client = new OpenTDF({
+  interceptors: [dpopInterceptor],
+  dpopKeys: dpopInterceptor.dpopKeys,
+  platformUrl: 'https://platform.example.com',
+});
+```
+
+You can also write your own interceptor for full control over request headers:
+
+```typescript
+import { type Interceptor } from '@connectrpc/connect';
+
+const myInterceptor: Interceptor = (next) => async (req) => {
+  req.header.set('Authorization', `Bearer ${await getToken()}`);
+  req.header.set('X-Custom-Header', 'value');
+  return next(req);
+};
+
+const client = new OpenTDF({
+  interceptors: [myInterceptor],
+  platformUrl: 'https://platform.example.com',
+});
+```
+
+### With AuthProvider (Legacy)
+
+The `AuthProvider` pattern is still supported for backwards compatibility.
+
+```typescript
+import { AuthProviders, OpenTDF } from '@opentdf/sdk';
+
+const authProvider = await AuthProviders.refreshAuthProvider({
+  clientId: 'my-client-id',
+  refreshToken: refreshToken,
+  oidcOrigin: 'https://keycloak.example.com/auth/realms/my-realm',
+});
+
+const client = new OpenTDF({
+  authProvider,
+  platformUrl: 'https://platform.example.com',
+});
 ```

--- a/lib/src/access.ts
+++ b/lib/src/access.ts
@@ -1,4 +1,4 @@
-import { type AuthProvider } from './auth/auth.js';
+import { type AuthConfig, resolveAuthConfig } from './auth/interceptors.js';
 import { RewrapResponse } from './platform/kas/kas_pb.js';
 import { getPlatformUrlFromKasEndpoint, validateSecureUrl } from './utils.js';
 import { base64 } from './encodings/index.js';
@@ -37,19 +37,28 @@ export type RewrapRequest = {
 export async function fetchWrappedKey(
   url: string,
   signedRequestToken: string,
-  authProvider: AuthProvider,
+  auth: AuthConfig,
   fulfillableObligationFQNs: string[]
 ): Promise<RewrapResponse> {
   const platformUrl = getPlatformUrlFromKasEndpoint(url);
+  const { interceptors, authProvider } = resolveAuthConfig(auth);
+
+  const rpcCall = () =>
+    fetchWrappedKeysRpc(
+      platformUrl,
+      signedRequestToken,
+      { interceptors },
+      rewrapAdditionalContextHeader(fulfillableObligationFQNs)
+    );
+
+  // When no AuthProvider is available, skip the legacy fallback so the real
+  // RPC error propagates instead of being masked by tryPromisesUntilFirstSuccess.
+  if (!authProvider) {
+    return await rpcCall();
+  }
 
   return await tryPromisesUntilFirstSuccess(
-    () =>
-      fetchWrappedKeysRpc(
-        platformUrl,
-        signedRequestToken,
-        authProvider,
-        rewrapAdditionalContextHeader(fulfillableObligationFQNs)
-      ),
+    rpcCall,
     // We intentionally do not provide the rewrap additional context to legacy requests destined for older platforms.
     // Platforms new enough to have knowledge of obligations will be handling RPC requests successfully.
     () =>
@@ -164,11 +173,18 @@ export type KasPublicKeyInfo = {
  */
 export async function fetchKeyAccessServers(
   platformUrl: string,
-  authProvider: AuthProvider
+  auth: AuthConfig
 ): Promise<OriginAllowList> {
-  return await tryPromisesUntilFirstSuccess(
-    () => fetchKeyAccessServersRpc(platformUrl, authProvider),
-    () => fetchKeyAccessServersLegacy(platformUrl, authProvider)
+  const { interceptors, authProvider } = resolveAuthConfig(auth);
+
+  const rpcCall = () => fetchKeyAccessServersRpc(platformUrl, { interceptors });
+
+  if (!authProvider) {
+    return await rpcCall();
+  }
+
+  return await tryPromisesUntilFirstSuccess(rpcCall, () =>
+    fetchKeyAccessServersLegacy(platformUrl, authProvider)
   );
 }
 

--- a/lib/src/access/access-rpc.ts
+++ b/lib/src/access/access-rpc.ts
@@ -6,7 +6,7 @@ import {
   OriginAllowList,
 } from '../access.js';
 
-import { type AuthProvider } from '../auth/auth.js';
+import { type AuthConfig, resolveInterceptors } from '../auth/interceptors.js';
 import {
   ConfigurationError,
   InvalidFileError,
@@ -37,11 +37,11 @@ import { ConnectError, Code } from '@connectrpc/connect';
 export async function fetchWrappedKey(
   url: string,
   signedRequestToken: string,
-  authProvider: AuthProvider,
+  auth: AuthConfig,
   rewrapAdditionalContextHeader?: string
 ): Promise<RewrapResponse> {
   const platformUrl = getPlatformUrlFromKasEndpoint(url);
-  const platform = new PlatformClient({ authProvider, platformUrl });
+  const platform = new PlatformClient({ interceptors: resolveInterceptors(auth), platformUrl });
   const options: CallOptions = {};
   if (rewrapAdditionalContextHeader) {
     options.headers = {
@@ -121,11 +121,11 @@ export function handleRpcRewrapErrorString(
 
 export async function fetchKeyAccessServers(
   platformUrl: string,
-  authProvider: AuthProvider
+  auth: AuthConfig
 ): Promise<OriginAllowList> {
   let nextOffset = 0;
   const allServers = [];
-  const platform = new PlatformClient({ authProvider, platformUrl });
+  const platform = new PlatformClient({ interceptors: resolveInterceptors(auth), platformUrl });
 
   do {
     let response: ListKeyAccessServersResponse;

--- a/lib/src/auth/interceptors.ts
+++ b/lib/src/auth/interceptors.ts
@@ -1,4 +1,5 @@
 import { type Interceptor } from '@connectrpc/connect';
+export type { Interceptor } from '@connectrpc/connect';
 import { type CryptoService, type KeyPair } from '../../tdf3/src/crypto/declarations.js';
 import * as DefaultCryptoService from '../../tdf3/src/crypto/index.js';
 import DPoP from './dpop.js';

--- a/lib/src/auth/interceptors.ts
+++ b/lib/src/auth/interceptors.ts
@@ -1,0 +1,196 @@
+import { type Interceptor } from '@connectrpc/connect';
+import { type CryptoService, type KeyPair } from '../../tdf3/src/crypto/declarations.js';
+import * as DefaultCryptoService from '../../tdf3/src/crypto/index.js';
+import DPoP from './dpop.js';
+import { type AuthProvider } from './auth.js';
+import { base64 } from '../encodings/index.js';
+
+/**
+ * A function that returns a valid access token string.
+ * Called per-request; implementations should handle caching/refresh internally.
+ */
+export type TokenProvider = () => Promise<string>;
+
+/**
+ * Options for creating a DPoP-aware auth interceptor.
+ */
+export type DPoPInterceptorOptions = {
+  /** Function that returns a valid access token (may cache/refresh internally). */
+  tokenProvider: TokenProvider;
+  /** DPoP signing key pair. If omitted, one is generated automatically. */
+  dpopKeys?: KeyPair | Promise<KeyPair>;
+  /** CryptoService for signing. Defaults to DefaultCryptoService. */
+  cryptoService?: CryptoService;
+};
+
+/**
+ * A DPoP interceptor that also exposes the resolved signing key pair.
+ * TDF encrypt/decrypt needs these keys for request body signing (reqSignature).
+ */
+export type DPoPInterceptor = Interceptor & {
+  /** The resolved DPoP key pair, for use in TDF request token signing. */
+  readonly dpopKeys: Promise<KeyPair>;
+};
+
+/**
+ * Creates a simple bearer-token interceptor.
+ * Calls `tokenProvider()` per-request and sets the `Authorization` header.
+ *
+ * @param tokenProvider Function returning a valid access token.
+ * @returns A Connect RPC Interceptor.
+ *
+ * @example
+ * ```ts
+ * const opentdf = new OpenTDF({
+ *   interceptors: [authTokenInterceptor(() => myAuth.getAccessToken())],
+ *   platformUrl: '/api',
+ * });
+ * ```
+ */
+export function authTokenInterceptor(tokenProvider: TokenProvider): Interceptor {
+  return (next) => async (req) => {
+    const token = await tokenProvider();
+    req.header.set('Authorization', `Bearer ${token}`);
+    return next(req);
+  };
+}
+
+/**
+ * Creates a DPoP-aware auth interceptor.
+ * Per-request: gets token, generates DPoP proof JWT, sets Authorization + DPoP + X-VirtruPubKey headers.
+ * Exposes `dpopKeys` for TDF request body signing.
+ *
+ * @param options DPoP interceptor configuration.
+ * @returns A DPoP interceptor with an exposed `dpopKeys` promise.
+ *
+ * @example
+ * ```ts
+ * const dpopInterceptor = authTokenDPoPInterceptor({
+ *   tokenProvider: () => myAuth.getAccessToken(),
+ * });
+ * const opentdf = new OpenTDF({
+ *   interceptors: [dpopInterceptor],
+ *   dpopKeys: dpopInterceptor.dpopKeys,
+ *   platformUrl: '/api',
+ * });
+ * ```
+ */
+export function authTokenDPoPInterceptor(options: DPoPInterceptorOptions): DPoPInterceptor {
+  const cryptoService = options.cryptoService ?? DefaultCryptoService;
+  const dpopKeysPromise: Promise<KeyPair> = options.dpopKeys
+    ? Promise.resolve(options.dpopKeys)
+    : cryptoService.generateSigningKeyPair();
+
+  const interceptor: Interceptor = (next) => async (req) => {
+    const [token, keys] = await Promise.all([options.tokenProvider(), dpopKeysPromise]);
+
+    const url = new URL(req.url);
+    const httpUri = `${url.origin}${url.pathname}`;
+
+    // Generate DPoP proof JWT for this request
+    const dpopProof = await DPoP(keys, cryptoService, httpUri, 'POST');
+
+    // Export public key PEM for X-VirtruPubKey header
+    const publicKeyPem = await cryptoService.exportPublicKeyPem(keys.publicKey);
+
+    req.header.set('Authorization', `Bearer ${token}`);
+    req.header.set('DPoP', dpopProof);
+    req.header.set('X-VirtruPubKey', base64.encode(publicKeyPem));
+
+    return next(req);
+  };
+
+  // Attach dpopKeys to the interceptor function
+  const dpopInterceptor = interceptor as DPoPInterceptor;
+  Object.defineProperty(dpopInterceptor, 'dpopKeys', {
+    value: dpopKeysPromise,
+    writable: false,
+    enumerable: true,
+  });
+
+  return dpopInterceptor;
+}
+
+/**
+ * Creates an interceptor that bridges an existing AuthProvider to the Interceptor pattern.
+ * Use this for backwards compatibility when migrating from AuthProvider to interceptors.
+ *
+ * @param authProvider The legacy AuthProvider to bridge.
+ * @returns A Connect RPC Interceptor.
+ */
+export function authProviderInterceptor(authProvider: AuthProvider): Interceptor {
+  return (next) => async (req) => {
+    const url = new URL(req.url);
+    const pathOnly = url.pathname;
+    // Signs only the path of the url in the request
+    let token;
+    try {
+      token = await authProvider.withCreds({
+        url: pathOnly,
+        method: 'POST',
+        // Start with any headers Connect already has
+        headers: {
+          ...Object.fromEntries(req.header.entries()),
+          'Content-Type': 'application/json',
+        },
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (msg.includes('public key') || msg.includes('updateClientPublicKey')) {
+        throw new Error(
+          'PlatformClient: DPoP key binding is not complete. ' +
+            'If you are using OpenTDF with PlatformClient, create OpenTDF first and ' +
+            '`await client.ready` before constructing PlatformClient. ' +
+            `Original error: ${msg}`
+        );
+      }
+      throw err;
+    }
+
+    Object.entries(token.headers).forEach(([key, value]) => {
+      req.header.set(key, value);
+    });
+
+    return await next(req);
+  };
+}
+
+/**
+ * Auth configuration: either a legacy AuthProvider or an object with interceptors.
+ */
+export type AuthConfig = AuthProvider | { interceptors: Interceptor[] };
+
+/**
+ * Type guard for AuthConfig with interceptors.
+ */
+export function isInterceptorConfig(auth: AuthConfig): auth is { interceptors: Interceptor[] } {
+  return 'interceptors' in auth && Array.isArray((auth as { interceptors: unknown }).interceptors);
+}
+
+/**
+ * Resolves an AuthConfig into interceptors for use with PlatformClient.
+ * If the config is an AuthProvider, it is bridged via authProviderInterceptor.
+ */
+export function resolveInterceptors(auth: AuthConfig): Interceptor[] {
+  if (isInterceptorConfig(auth)) {
+    return auth.interceptors;
+  }
+  return [authProviderInterceptor(auth)];
+}
+
+/**
+ * Resolves an AuthConfig into both interceptors and an optional AuthProvider.
+ * The AuthProvider is available for legacy code paths that need withCreds().
+ */
+export function resolveAuthConfig(auth: AuthConfig): {
+  interceptors: Interceptor[];
+  authProvider?: AuthProvider;
+} {
+  if (isInterceptorConfig(auth)) {
+    return { interceptors: auth.interceptors };
+  }
+  return {
+    interceptors: [authProviderInterceptor(auth)],
+    authProvider: auth,
+  };
+}

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -1,5 +1,14 @@
 export { type AuthProvider, type HttpMethod, HttpRequest, withHeaders } from './auth/auth.js';
 export * as AuthProviders from './auth/providers.js';
+export {
+  authTokenInterceptor,
+  authTokenDPoPInterceptor,
+  authProviderInterceptor,
+  type AuthConfig,
+  type DPoPInterceptor,
+  type DPoPInterceptorOptions,
+  type TokenProvider,
+} from './auth/interceptors.js';
 export { attributeFQNsAsValues } from './policy/api.js';
 export {
   listAttributes,

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -7,6 +7,7 @@ export {
   type AuthConfig,
   type DPoPInterceptor,
   type DPoPInterceptorOptions,
+  type Interceptor,
   type TokenProvider,
 } from './auth/interceptors.js';
 export { attributeFQNsAsValues } from './policy/api.js';

--- a/lib/src/opentdf.ts
+++ b/lib/src/opentdf.ts
@@ -173,7 +173,7 @@ export type OpenTDFOptions = {
 
   /**
    * Auth provider for connections to the policy service and KASes.
-   * @deprecated Use `interceptors` with `authTokenInterceptor()` or `authTokenDPoPInterceptor()` instead.
+   * @deprecated since 0.14.0. Use `interceptors` with `authTokenInterceptor()` or `authTokenDPoPInterceptor()` instead.
    */
   authProvider?: AuthProvider;
 

--- a/lib/src/opentdf.ts
+++ b/lib/src/opentdf.ts
@@ -246,18 +246,10 @@ export type TDFReader = {
  * It also requires a platform URL to be set, which is used to fetch key access servers and policies.
  * @example
  * ```
- * import { type Chunker, OpenTDF } from '@opentdf/sdk';
- *
- * const oidcCredentials: RefreshTokenCredentials = {
- *   clientId: keycloakClientId,
- *   exchange: 'refresh',
- *   refreshToken: refreshToken,
- *   oidcOrigin: keycloakUrl,
- * };
- * const authProvider = await AuthProviders.refreshAuthProvider(oidcCredentials);
+ * import { authTokenInterceptor, OpenTDF } from '@opentdf/sdk';
  *
  * const client = new OpenTDF({
- *   authProvider,
+ *   interceptors: [authTokenInterceptor(() => `${myAuth.token.accessToken}`)],
  *   platformUrl: 'https://platform.example.com',
  * });
  *

--- a/lib/src/opentdf.ts
+++ b/lib/src/opentdf.ts
@@ -513,7 +513,7 @@ class ZTDFReader {
 
     const dpopKeys = await this.client.dpopKeys;
 
-    const { auth, authProvider, cryptoService } = this.client;
+    const { auth, cryptoService } = this.client;
     if (!auth) {
       throw new ConfigurationError('authProvider or interceptors are required');
     }
@@ -534,7 +534,6 @@ class ZTDFReader {
       {
         allowList,
         auth,
-        authProvider,
         chunker: this.source,
         concurrencyLimit: 1,
         cryptoService,

--- a/lib/src/opentdf.ts
+++ b/lib/src/opentdf.ts
@@ -1,4 +1,5 @@
 import { type AuthProvider } from './auth/providers.js';
+import { type Interceptor } from '@connectrpc/connect';
 import { ConfigurationError, InvalidFileError } from './errors.js';
 export { Client as TDF3Client } from '../tdf3/src/client/index.js';
 import { Chunker, fromSource, sourceToStream, type Source } from './seekable.js';
@@ -164,8 +165,17 @@ export type OpenTDFOptions = {
   /** Platform URL. */
   platformUrl?: string;
 
-  /** Auth provider for connections to the policy service and KASes. */
-  authProvider: AuthProvider;
+  /**
+   * Connect RPC interceptors for authentication. Preferred over authProvider.
+   * Use `authTokenInterceptor()` or `authTokenDPoPInterceptor()` to create interceptors.
+   */
+  interceptors?: Interceptor[];
+
+  /**
+   * Auth provider for connections to the policy service and KASes.
+   * @deprecated Use `interceptors` with `authTokenInterceptor()` or `authTokenDPoPInterceptor()` instead.
+   */
+  authProvider?: AuthProvider;
 
   /** Default settings for 'encrypt' type requests. */
   defaultCreateOptions?: Omit<CreateOptions, 'source'>;
@@ -264,8 +274,10 @@ export class OpenTDF {
   readonly platformUrl: string;
   /** The policy service endpoint */
   readonly policyEndpoint: string;
-  /** The auth provider for the OpenTDF instance. */
-  readonly authProvider: AuthProvider;
+  /** The auth provider for the OpenTDF instance (deprecated, use interceptors). */
+  readonly authProvider?: AuthProvider;
+  /** Connect RPC interceptors for authentication. */
+  readonly interceptors?: Interceptor[];
   /** If DPoP is enabled for this instance. */
   readonly dpopEnabled: boolean;
   /** Default options for creating TDF objects. */
@@ -283,6 +295,7 @@ export class OpenTDF {
 
   constructor({
     authProvider,
+    interceptors,
     dpopKeys,
     defaultCreateOptions,
     defaultReadOptions,
@@ -291,7 +304,11 @@ export class OpenTDF {
     platformUrl,
     cryptoService,
   }: OpenTDFOptions) {
+    if (!authProvider && !interceptors?.length) {
+      throw new ConfigurationError('Either authProvider or interceptors must be provided.');
+    }
     this.authProvider = authProvider;
+    this.interceptors = interceptors;
     this.defaultCreateOptions = defaultCreateOptions || {};
     this.defaultReadOptions = defaultReadOptions || {};
     this.dpopEnabled = !disableDPoP;
@@ -308,6 +325,7 @@ export class OpenTDF {
     this.dpopKeys = dpopKeys ?? this.cryptoService.generateSigningKeyPair();
     this.tdf3Client = new TDF3Client({
       authProvider,
+      interceptors,
       dpopEnabled: this.dpopEnabled,
       dpopKeys: this.dpopEnabled ? this.dpopKeys : undefined,
       kasEndpoint: this.platformUrl || 'https://disallow.all.invalid',
@@ -315,21 +333,31 @@ export class OpenTDF {
       policyEndpoint,
       cryptoService: this.cryptoService,
     });
-    // Eagerly bind DPoP keys to the auth provider so PlatformClient
-    // can make gRPC calls without waiting for a TDF operation first.
-    // Note: TDF3Client.createSessionKeys() also calls updateClientPublicKey
-    // with the same keys, but the duplicate call is benign —
-    // refreshTokenClaimsWithClientPubkeyIfNeeded short-circuits when
-    // the signing key hasn't changed.
-    this.ready = this.dpopEnabled
-      ? this.dpopKeys.then((keys) => authProvider.updateClientPublicKey(keys))
-      : Promise.resolve();
-    // Prevent unhandled rejection if caller doesn't await ready.
-    // The error will still surface via TDF3Client's own key binding
-    // when encrypt/decrypt is called.
-    this.ready.catch((err) => {
-      console.warn('OpenTDF: DPoP key binding failed during initialization:', err);
-    });
+
+    if (interceptors?.length && !authProvider) {
+      // Interceptor path: no updateClientPublicKey needed.
+      // DPoP key binding is handled by the interceptor itself.
+      this.ready = Promise.resolve();
+    } else if (authProvider) {
+      // Legacy AuthProvider path: eagerly bind DPoP keys to the auth provider
+      // so PlatformClient can make gRPC calls without waiting for a TDF
+      // operation first.
+      // Note: TDF3Client.createSessionKeys() also calls updateClientPublicKey
+      // with the same keys, but the duplicate call is benign —
+      // refreshTokenClaimsWithClientPubkeyIfNeeded short-circuits when
+      // the signing key hasn't changed.
+      this.ready = this.dpopEnabled
+        ? this.dpopKeys.then((keys) => authProvider.updateClientPublicKey(keys))
+        : Promise.resolve();
+      // Prevent unhandled rejection if caller doesn't await ready.
+      // The error will still surface via TDF3Client's own key binding
+      // when encrypt/decrypt is called.
+      this.ready.catch((err) => {
+        console.warn('OpenTDF: DPoP key binding failed during initialization:', err);
+      });
+    } else {
+      this.ready = Promise.resolve();
+    }
   }
 
   /** Creates a new TDF stream. */
@@ -485,9 +513,9 @@ class ZTDFReader {
 
     const dpopKeys = await this.client.dpopKeys;
 
-    const { authProvider, cryptoService } = this.client;
-    if (!authProvider) {
-      throw new ConfigurationError('authProvider is required');
+    const { auth, authProvider, cryptoService } = this.client;
+    if (!auth) {
+      throw new ConfigurationError('authProvider or interceptors are required');
     }
 
     let allowList: OriginAllowList | undefined;
@@ -498,13 +526,14 @@ class ZTDFReader {
         this.opts.ignoreAllowlist
       );
     } else if (this.opts.platformUrl) {
-      allowList = await fetchKeyAccessServers(this.opts.platformUrl, authProvider);
+      allowList = await fetchKeyAccessServers(this.opts.platformUrl, auth);
     }
 
     const overview = await this.overview;
     const oldStream = await decryptStreamFrom(
       {
         allowList,
+        auth,
         authProvider,
         chunker: this.source,
         concurrencyLimit: 1,

--- a/lib/src/platform.ts
+++ b/lib/src/platform.ts
@@ -47,7 +47,7 @@ export interface PlatformServicesV2 {
 export interface PlatformClientOptions {
   /**
    * Authentication provider for generating auth interceptor.
-   * @deprecated Use `interceptors` with `authTokenInterceptor()` or `authTokenDPoPInterceptor()` instead.
+   * @deprecated since 0.14.0. Use `interceptors` with `authTokenInterceptor()` or `authTokenDPoPInterceptor()` instead.
    */
   authProvider?: AuthProvider;
   /** Array of interceptors to apply to rpc requests. Preferred over authProvider. */

--- a/lib/src/platform.ts
+++ b/lib/src/platform.ts
@@ -3,7 +3,8 @@ export * as platformConnectWeb from '@connectrpc/connect-web';
 export * as platformConnect from '@connectrpc/connect';
 
 import { createConnectTransport } from '@connectrpc/connect-web';
-import { AuthProvider } from '../tdf3/index.js';
+import type { AuthProvider } from '../tdf3/index.js';
+import { authProviderInterceptor } from './auth/interceptors.js';
 
 import { Client, createClient, Interceptor } from '@connectrpc/connect';
 import { WellKnownService } from './platform/wellknownconfiguration/wellknown_configuration_pb.js';
@@ -44,9 +45,12 @@ export interface PlatformServicesV2 {
 }
 
 export interface PlatformClientOptions {
-  /** Optional authentication provider for generating auth interceptor. */
+  /**
+   * Authentication provider for generating auth interceptor.
+   * @deprecated Use `interceptors` with `authTokenInterceptor()` or `authTokenDPoPInterceptor()` instead.
+   */
   authProvider?: AuthProvider;
-  /** Array of custom interceptors to apply to rpc requests. */
+  /** Array of interceptors to apply to rpc requests. Preferred over authProvider. */
   interceptors?: Interceptor[];
   /** Base URL of the platform API. */
   platformUrl: string;
@@ -85,8 +89,7 @@ export class PlatformClient {
     const interceptors: Interceptor[] = [];
 
     if (options.authProvider) {
-      const authInterceptor = createAuthInterceptor(options.authProvider);
-      interceptors.push(authInterceptor);
+      interceptors.push(authProviderInterceptor(options.authProvider));
     }
 
     if (options.interceptors?.length) {
@@ -119,51 +122,4 @@ export class PlatformClient {
       authorization: createClient(AuthorizationServiceV2, transport),
     };
   }
-}
-
-/**
- * Creates an interceptor that adds authentication headers to outgoing requests.
- *
- * This function uses the provided `AuthProvider` to generate authentication credentials
- * for each request. The `AuthProvider` is expected to implement a `withCreds` method
- * that returns an object containing authentication headers. These headers are then
- * added to the request before it is sent to the server.
- *
- */
-function createAuthInterceptor(authProvider: AuthProvider): Interceptor {
-  const authInterceptor: Interceptor = (next) => async (req) => {
-    const url = new URL(req.url);
-    const pathOnly = url.pathname;
-    // Signs only the path of the url in the request
-    let token;
-    try {
-      token = await authProvider.withCreds({
-        url: pathOnly,
-        method: 'POST',
-        // Start with any headers Connect already has
-        headers: {
-          ...Object.fromEntries(req.header.entries()),
-          'Content-Type': 'application/json',
-        },
-      });
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      if (msg.includes('public key') || msg.includes('updateClientPublicKey')) {
-        throw new Error(
-          'PlatformClient: DPoP key binding is not complete. ' +
-            'If you are using OpenTDF with PlatformClient, create OpenTDF first and ' +
-            '`await client.ready` before constructing PlatformClient. ' +
-            `Original error: ${msg}`
-        );
-      }
-      throw err;
-    }
-
-    Object.entries(token.headers).forEach(([key, value]) => {
-      req.header.set(key, value);
-    });
-
-    return await next(req);
-  };
-  return authInterceptor;
 }

--- a/lib/src/policy/api.ts
+++ b/lib/src/policy/api.ts
@@ -1,5 +1,5 @@
 import { NetworkError } from '../errors.js';
-import { AuthProvider } from '../auth/auth.js';
+import { type AuthConfig, resolveInterceptors } from '../auth/interceptors.js';
 import { extractRpcErrorMessage, getPlatformUrlFromKasEndpoint } from '../utils.js';
 import { PlatformClient } from '../platform.js';
 import { Value } from './attributes.js';
@@ -12,11 +12,11 @@ import { ValueSchema } from '../platform/policy/objects_pb.js';
 // TODO KAS: go over web-sdk and remove policyEndpoint that is only defined to be used here
 export async function attributeFQNsAsValues(
   platformUrl: string,
-  authProvider: AuthProvider,
+  auth: AuthConfig,
   ...fqns: string[]
 ): Promise<Value[]> {
   platformUrl = getPlatformUrlFromKasEndpoint(platformUrl);
-  const platform = new PlatformClient({ authProvider, platformUrl });
+  const platform = new PlatformClient({ interceptors: resolveInterceptors(auth), platformUrl });
 
   let response: GetAttributeValuesByFqnsResponse;
   try {
@@ -52,7 +52,7 @@ export async function attributeFQNsAsValues(
 // Get root certificates from a namespace
 export async function getRootCertsFromNamespace(
   platformUrl: string,
-  authProvider?: AuthProvider,
+  auth?: AuthConfig,
   namespaceId?: string,
   fqn?: string
 ): Promise<Certificate[]> {
@@ -63,7 +63,10 @@ export async function getRootCertsFromNamespace(
     throw new Error('Either namespaceId or fqn must be provided');
   }
 
-  const platform = new PlatformClient({ authProvider, platformUrl });
+  const platform = new PlatformClient({
+    ...(auth ? { interceptors: resolveInterceptors(auth) } : {}),
+    platformUrl,
+  });
 
   let response: GetNamespaceResponse;
   try {

--- a/lib/src/policy/discovery.ts
+++ b/lib/src/policy/discovery.ts
@@ -1,6 +1,6 @@
 import { ConnectError, Code } from '@connectrpc/connect';
 import { AttributeNotFoundError, ConfigurationError, NetworkError } from '../errors.js';
-import { type AuthProvider } from '../auth/auth.js';
+import { type AuthConfig, resolveInterceptors } from '../auth/interceptors.js';
 import { extractRpcErrorMessage, validateSecureUrl } from '../utils.js';
 import { PlatformClient } from '../platform.js';
 import type { Attribute } from '../platform/policy/objects_pb.js';
@@ -49,13 +49,13 @@ const ATTRIBUTE_FQN_RE = /^https?:\/\/[a-zA-Z0-9._~%-]+\/attr\/[a-zA-Z0-9._~%-]+
  */
 export async function listAttributes(
   platformUrl: string,
-  authProvider: AuthProvider,
+  auth: AuthConfig,
   namespace?: string
 ): Promise<Attribute[]> {
   if (!validateSecureUrl(platformUrl)) {
     throw new ConfigurationError('platformUrl must use HTTPS protocol');
   }
-  const platform = new PlatformClient({ authProvider, platformUrl });
+  const platform = new PlatformClient({ interceptors: resolveInterceptors(auth), platformUrl });
   const result: Attribute[] = [];
   let nextOffset = 0;
 
@@ -106,7 +106,7 @@ export async function listAttributes(
  */
 export async function validateAttributes(
   platformUrl: string,
-  authProvider: AuthProvider,
+  auth: AuthConfig,
   fqns: string[]
 ): Promise<void> {
   if (!fqns || fqns.length === 0) {
@@ -129,7 +129,7 @@ export async function validateAttributes(
     }
   }
 
-  const platform = new PlatformClient({ authProvider, platformUrl });
+  const platform = new PlatformClient({ interceptors: resolveInterceptors(auth), platformUrl });
   let resp;
   try {
     resp = await platform.v1.attributes.getAttributeValuesByFqns({ fqns });
@@ -159,7 +159,7 @@ export async function validateAttributes(
  */
 export async function attributeExists(
   platformUrl: string,
-  authProvider: AuthProvider,
+  auth: AuthConfig,
   attributeFqn: string
 ): Promise<boolean> {
   if (!validateSecureUrl(platformUrl)) {
@@ -170,7 +170,7 @@ export async function attributeExists(
     throw new ConfigurationError('invalid attribute FQN format');
   }
 
-  const platform = new PlatformClient({ authProvider, platformUrl });
+  const platform = new PlatformClient({ interceptors: resolveInterceptors(auth), platformUrl });
   try {
     await platform.v1.attributes.getAttribute({
       identifier: { case: 'fqn', value: attributeFqn },
@@ -199,7 +199,7 @@ export async function attributeExists(
  */
 export async function attributeValueExists(
   platformUrl: string,
-  authProvider: AuthProvider,
+  auth: AuthConfig,
   valueFqn: string
 ): Promise<boolean> {
   if (!validateSecureUrl(platformUrl)) {
@@ -210,7 +210,7 @@ export async function attributeValueExists(
     throw new ConfigurationError('invalid attribute value FQN format');
   }
 
-  const platform = new PlatformClient({ authProvider, platformUrl });
+  const platform = new PlatformClient({ interceptors: resolveInterceptors(auth), platformUrl });
   let resp;
   try {
     resp = await platform.v1.attributes.getAttributeValuesByFqns({ fqns: [valueFqn] });

--- a/lib/tdf3/src/client/index.ts
+++ b/lib/tdf3/src/client/index.ts
@@ -352,10 +352,11 @@ export class Client {
 
   readonly clientId?: string;
 
-  readonly authProvider?: AuthProvider;
-
-  /** Connect RPC interceptors for authentication. */
-  readonly interceptors?: Interceptor[];
+  /**
+   * Resolved auth configuration. Set once in the constructor from either
+   * authProvider or interceptors. Threaded through all internal layers.
+   */
+  readonly auth?: AuthConfig;
 
   readonly readerUrl?: string;
 
@@ -432,12 +433,12 @@ export class Client {
       this.easEndpoint = clientConfig.easEndpoint;
     }
 
-    this.authProvider = config.authProvider;
-    this.interceptors = config.interceptors;
     this.clientConfig = clientConfig;
 
+    // Resolve auth once at the boundary. Internally, only `this.auth` is used.
+    let authProvider = config.authProvider;
     this.clientId = clientConfig.clientId;
-    if (!this.authProvider && !this.interceptors?.length) {
+    if (!authProvider && !config.interceptors?.length) {
       if (!clientConfig.clientId) {
         throw new ConfigurationError(
           'Client ID, custom AuthProvider, or interceptors must be defined'
@@ -449,7 +450,7 @@ export class Client {
       //browser-based OIDC login and authentication process against the OIDC endpoint using their chosen method,
       //and provide us with a valid refresh token/clientId obtained from that process.
       if (clientConfig.refreshToken) {
-        this.authProvider = new OIDCRefreshTokenProvider(
+        authProvider = new OIDCRefreshTokenProvider(
           {
             clientId: clientConfig.clientId,
             refreshToken: clientConfig.refreshToken,
@@ -459,7 +460,7 @@ export class Client {
         );
       } else if (clientConfig.externalJwt) {
         //Are we exchanging a JWT previously issued by a trusted external entity (e.g. Google) for a bearer token?
-        this.authProvider = new OIDCExternalJwtProvider(
+        authProvider = new OIDCExternalJwtProvider(
           {
             clientId: clientConfig.clientId,
             externalJwt: clientConfig.externalJwt,
@@ -469,28 +470,25 @@ export class Client {
         );
       }
     }
-    if (this.interceptors?.length && !this.authProvider) {
+
+    // Resolve to AuthConfig: interceptors take precedence over authProvider.
+    if (config.interceptors?.length) {
+      this.auth = { interceptors: config.interceptors };
+    } else if (authProvider) {
+      this.auth = authProvider;
+    }
+
+    if (config.interceptors?.length && !authProvider) {
       // Interceptor path: no updateClientPublicKey needed.
       // Still need dpopKeys for request body signing (reqSignature).
       this.dpopKeys = clientConfig.dpopKeys ?? this.cryptoService.generateSigningKeyPair();
     } else {
       this.dpopKeys = createSessionKeys({
-        authProvider: this.authProvider,
+        authProvider,
         cryptoService: this.cryptoService,
         dpopKeys: clientConfig.dpopKeys,
       });
     }
-  }
-
-  /**
-   * Returns the auth configuration for this client.
-   * Prefers interceptors over authProvider.
-   */
-  get auth(): AuthConfig | undefined {
-    if (this.interceptors?.length) {
-      return { interceptors: this.interceptors };
-    }
-    return this.authProvider;
   }
 
   /** Necessary only for testing. A dependency-injection approach should be preferred, but that is difficult currently */
@@ -771,7 +769,6 @@ export class Client {
       mimeType,
       policy: policyObject,
       auth: this.auth,
-      authProvider: this.authProvider,
       progressHandler: this.clientConfig.progressHandler,
       keyForEncryption,
       keyForManifest,
@@ -831,7 +828,6 @@ export class Client {
       await readStream({
         allowList,
         auth: this.auth,
-        authProvider: this.authProvider,
         chunker,
         concurrencyLimit,
         cryptoService: this.cryptoService,

--- a/lib/tdf3/src/client/index.ts
+++ b/lib/tdf3/src/client/index.ts
@@ -19,6 +19,8 @@ import { OIDCRefreshTokenProvider } from '../../../src/auth/oidc-refreshtoken-pr
 import { OIDCExternalJwtProvider } from '../../../src/auth/oidc-externaljwt-provider.js';
 import { CryptoService } from '../crypto/declarations.js';
 import { type AuthProvider, HttpRequest, withHeaders } from '../../../src/auth/auth.js';
+import { type AuthConfig } from '../../../src/auth/interceptors.js';
+import { type Interceptor } from '@connectrpc/connect';
 import { getPlatformUrlFromKasEndpoint, rstrip, validateSecureUrl } from '../../../src/utils.js';
 
 import {
@@ -154,7 +156,10 @@ export interface ClientConfig {
   kasPublicKey?: string;
   oidcOrigin?: string;
   externalJwt?: string;
+  /** @deprecated Use `interceptors` instead. */
   authProvider?: AuthProvider;
+  /** Connect RPC interceptors for authentication. Preferred over authProvider. */
+  interceptors?: Interceptor[];
   readerUrl?: string;
   entityObjectEndpoint?: string;
   fileStreamServiceWorker?: string;
@@ -349,6 +354,9 @@ export class Client {
 
   readonly authProvider?: AuthProvider;
 
+  /** Connect RPC interceptors for authentication. */
+  readonly interceptors?: Interceptor[];
+
   readonly readerUrl?: string;
 
   readonly fileStreamServiceWorker?: string;
@@ -425,12 +433,15 @@ export class Client {
     }
 
     this.authProvider = config.authProvider;
+    this.interceptors = config.interceptors;
     this.clientConfig = clientConfig;
 
     this.clientId = clientConfig.clientId;
-    if (!this.authProvider) {
+    if (!this.authProvider && !this.interceptors?.length) {
       if (!clientConfig.clientId) {
-        throw new ConfigurationError('Client ID or custom AuthProvider must be defined');
+        throw new ConfigurationError(
+          'Client ID, custom AuthProvider, or interceptors must be defined'
+        );
       }
 
       //Are we exchanging a refreshToken for a bearer token (normal AuthCode browser auth flow)?
@@ -458,11 +469,28 @@ export class Client {
         );
       }
     }
-    this.dpopKeys = createSessionKeys({
-      authProvider: this.authProvider,
-      cryptoService: this.cryptoService,
-      dpopKeys: clientConfig.dpopKeys,
-    });
+    if (this.interceptors?.length && !this.authProvider) {
+      // Interceptor path: no updateClientPublicKey needed.
+      // Still need dpopKeys for request body signing (reqSignature).
+      this.dpopKeys = clientConfig.dpopKeys ?? this.cryptoService.generateSigningKeyPair();
+    } else {
+      this.dpopKeys = createSessionKeys({
+        authProvider: this.authProvider,
+        cryptoService: this.cryptoService,
+        dpopKeys: clientConfig.dpopKeys,
+      });
+    }
+  }
+
+  /**
+   * Returns the auth configuration for this client.
+   * Prefers interceptors over authProvider.
+   */
+  get auth(): AuthConfig | undefined {
+    if (this.interceptors?.length) {
+      return { interceptors: this.interceptors };
+    }
+    return this.authProvider;
   }
 
   /** Necessary only for testing. A dependency-injection approach should be preferred, but that is difficult currently */
@@ -566,9 +594,12 @@ export class Client {
         if (!this.platformUrl) {
           throw new ConfigurationError('platformUrl not set in TDF3 Client constructor');
         }
+        if (!this.auth) {
+          throw new ConfigurationError('AuthProvider or interceptors required for autoconfigure');
+        }
         const fetchedFQNValues = await attributeFQNsAsValues(
           this.platformUrl,
-          this.authProvider as AuthProvider,
+          this.auth,
           ...fqnsWithoutValues
         );
         fetchedFQNValues.forEach((fetchedValue) => {
@@ -739,6 +770,7 @@ export class Client {
       contentStream: opts.source,
       mimeType,
       policy: policyObject,
+      auth: this.auth,
       authProvider: this.authProvider,
       progressHandler: this.clientConfig.progressHandler,
       keyForEncryption,
@@ -775,14 +807,14 @@ export class Client {
     fulfillableObligationFQNs = [],
   }: DecryptParams): Promise<DecoratedReadableStream> {
     const dpopKeys = await this.dpopKeys;
-    if (!this.authProvider) {
-      throw new ConfigurationError('AuthProvider missing');
+    if (!this.auth) {
+      throw new ConfigurationError('AuthProvider or interceptors missing');
     }
     const chunker = await makeChunkable(source);
     if (!allowList && this.allowedKases) {
       allowList = this.allowedKases;
     } else if (this.platformUrl) {
-      allowList = await fetchKeyAccessServers(this.platformUrl, this.authProvider);
+      allowList = await fetchKeyAccessServers(this.platformUrl, this.auth);
     } else {
       throw new ConfigurationError('platformUrl is required when allowedKases is empty');
     }
@@ -798,6 +830,7 @@ export class Client {
     return await (streamMiddleware as DecryptStreamMiddleware)(
       await readStream({
         allowList,
+        auth: this.auth,
         authProvider: this.authProvider,
         chunker,
         concurrencyLimit,

--- a/lib/tdf3/src/client/index.ts
+++ b/lib/tdf3/src/client/index.ts
@@ -156,7 +156,7 @@ export interface ClientConfig {
   kasPublicKey?: string;
   oidcOrigin?: string;
   externalJwt?: string;
-  /** @deprecated Use `interceptors` instead. */
+  /** @deprecated since 0.14.0. Use `interceptors` instead. */
   authProvider?: AuthProvider;
   /** Connect RPC interceptors for authentication. Preferred over authProvider. */
   interceptors?: Interceptor[];

--- a/lib/tdf3/src/tdf.ts
+++ b/lib/tdf3/src/tdf.ts
@@ -15,6 +15,7 @@ import {
   UnsignedRewrapRequest_WithKeyAccessObjectSchema,
 } from '../../src/platform/kas/kas_pb.js';
 import { type AuthProvider, reqSignature } from '../../src/auth/auth.js';
+import { type AuthConfig } from '../../src/auth/interceptors.js';
 import { handleRpcRewrapErrorString } from '../../src/access/access-rpc.js';
 import { allPool, anyPool } from '../../src/concurrency.js';
 import { base64, hex } from '../../src/encodings/index.js';
@@ -152,7 +153,10 @@ export type EncryptConfiguration = {
   contentStream: ReadableStream<Uint8Array>;
   mimeType?: string;
   policy: Policy;
+  /** @deprecated Use `auth` instead. */
   authProvider?: AuthProvider;
+  /** Auth configuration: AuthProvider or { interceptors }. Preferred over authProvider. */
+  auth?: AuthConfig;
   byteLimit: number;
   progressHandler?: (bytesProcessed: number) => void;
   keyForEncryption: KeyInfo;
@@ -166,7 +170,10 @@ export type DecryptConfiguration = {
   fulfillableObligations: string[];
   allowedKases?: string[];
   allowList?: OriginAllowList;
-  authProvider: AuthProvider;
+  /** @deprecated Use `auth` instead. */
+  authProvider?: AuthProvider;
+  /** Auth configuration: AuthProvider or { interceptors }. Preferred over authProvider. */
+  auth?: AuthConfig;
   cryptoService: CryptoService;
 
   dpopKeys: KeyPair;
@@ -371,7 +378,7 @@ function isTargetSpecLegacyTDF(targetSpecVersion?: string): boolean {
 }
 
 export async function writeStream(cfg: EncryptConfiguration): Promise<DecoratedReadableStream> {
-  if (!cfg.authProvider) {
+  if (!cfg.auth && !cfg.authProvider) {
     throw new ConfigurationError('No authorization middleware defined');
   }
   if (!cfg.contentStream) {
@@ -737,6 +744,7 @@ type RewrapResponseData = {
 async function unwrapKey({
   manifest,
   allowedKases,
+  auth,
   authProvider,
   dpopKeys,
   concurrencyLimit,
@@ -746,18 +754,20 @@ async function unwrapKey({
 }: {
   manifest: Manifest;
   allowedKases: OriginAllowList;
-  authProvider: AuthProvider;
+  /** @deprecated Use `auth` instead. */
+  authProvider?: AuthProvider;
+  /** Auth configuration: AuthProvider or { interceptors }. Preferred over authProvider. */
+  auth?: AuthConfig;
   concurrencyLimit?: number;
   dpopKeys: KeyPair;
   cryptoService: CryptoService;
   wrappingKeyAlgorithm?: KasPublicKeyAlgorithm;
   fulfillableObligations: string[];
 }) {
-  if (authProvider === undefined) {
-    throw new ConfigurationError(
-      'rewrap requires auth provider; must be configured in client constructor'
-    );
+  if (!auth && !authProvider) {
+    throw new ConfigurationError('rewrap requires auth; must be configured in client constructor');
   }
+  const resolvedAuth: AuthConfig = (auth ?? authProvider) as AuthConfig;
   const { keyAccess } = manifest.encryptionInformation;
   const splitPotentials = splitLookupTableFactory(keyAccess, allowedKases);
 
@@ -829,7 +839,7 @@ async function unwrapKey({
     const rewrapResp = await fetchWrappedKey(
       url,
       signedRequestToken,
-      authProvider,
+      resolvedAuth,
       fulfillableObligations
     );
     // Upgrade V1 response to V2 format if needed
@@ -1143,6 +1153,7 @@ export async function decryptStreamFrom(
   const { metadata, reconstructedKey, requiredObligations } = await unwrapKey({
     fulfillableObligations: cfg.fulfillableObligations,
     manifest,
+    auth: cfg.auth,
     authProvider: cfg.authProvider,
     allowedKases: allowList,
     dpopKeys: cfg.dpopKeys,

--- a/lib/tdf3/src/tdf.ts
+++ b/lib/tdf3/src/tdf.ts
@@ -153,9 +153,7 @@ export type EncryptConfiguration = {
   contentStream: ReadableStream<Uint8Array>;
   mimeType?: string;
   policy: Policy;
-  /** @deprecated Use `auth` instead. */
-  authProvider?: AuthProvider;
-  /** Auth configuration: AuthProvider or { interceptors }. Preferred over authProvider. */
+  /** Auth configuration: AuthProvider or { interceptors }. */
   auth?: AuthConfig;
   byteLimit: number;
   progressHandler?: (bytesProcessed: number) => void;
@@ -170,9 +168,7 @@ export type DecryptConfiguration = {
   fulfillableObligations: string[];
   allowedKases?: string[];
   allowList?: OriginAllowList;
-  /** @deprecated Use `auth` instead. */
-  authProvider?: AuthProvider;
-  /** Auth configuration: AuthProvider or { interceptors }. Preferred over authProvider. */
+  /** Auth configuration: AuthProvider or { interceptors }. */
   auth?: AuthConfig;
   cryptoService: CryptoService;
 
@@ -378,7 +374,7 @@ function isTargetSpecLegacyTDF(targetSpecVersion?: string): boolean {
 }
 
 export async function writeStream(cfg: EncryptConfiguration): Promise<DecoratedReadableStream> {
-  if (!cfg.auth && !cfg.authProvider) {
+  if (!cfg.auth) {
     throw new ConfigurationError('No authorization middleware defined');
   }
   if (!cfg.contentStream) {
@@ -745,7 +741,6 @@ async function unwrapKey({
   manifest,
   allowedKases,
   auth,
-  authProvider,
   dpopKeys,
   concurrencyLimit,
   cryptoService,
@@ -754,9 +749,7 @@ async function unwrapKey({
 }: {
   manifest: Manifest;
   allowedKases: OriginAllowList;
-  /** @deprecated Use `auth` instead. */
-  authProvider?: AuthProvider;
-  /** Auth configuration: AuthProvider or { interceptors }. Preferred over authProvider. */
+  /** Auth configuration: AuthProvider or { interceptors }. */
   auth?: AuthConfig;
   concurrencyLimit?: number;
   dpopKeys: KeyPair;
@@ -764,10 +757,10 @@ async function unwrapKey({
   wrappingKeyAlgorithm?: KasPublicKeyAlgorithm;
   fulfillableObligations: string[];
 }) {
-  if (!auth && !authProvider) {
+  if (!auth) {
     throw new ConfigurationError('rewrap requires auth; must be configured in client constructor');
   }
-  const resolvedAuth: AuthConfig = (auth ?? authProvider) as AuthConfig;
+  const resolvedAuth: AuthConfig = auth;
   const { keyAccess } = manifest.encryptionInformation;
   const splitPotentials = splitLookupTableFactory(keyAccess, allowedKases);
 
@@ -1154,7 +1147,6 @@ export async function decryptStreamFrom(
     fulfillableObligations: cfg.fulfillableObligations,
     manifest,
     auth: cfg.auth,
-    authProvider: cfg.authProvider,
     allowedKases: allowList,
     dpopKeys: cfg.dpopKeys,
     cryptoService: cfg.cryptoService,

--- a/lib/tests/web/interceptors.test.ts
+++ b/lib/tests/web/interceptors.test.ts
@@ -1,0 +1,210 @@
+import { expect } from '@esm-bundle/chai';
+import { type Interceptor } from '@connectrpc/connect';
+import type { AuthProvider } from '../../src/auth/auth.js';
+import { HttpRequest, withHeaders } from '../../src/auth/auth.js';
+import {
+  authTokenInterceptor,
+  authTokenDPoPInterceptor,
+  authProviderInterceptor,
+  resolveInterceptors,
+  resolveAuthConfig,
+  isInterceptorConfig,
+} from '../../src/auth/interceptors.js';
+
+// --- helpers ---
+
+/** Runs an interceptor and captures the headers it sets on the request. */
+async function captureHeaders(
+  interceptor: Interceptor,
+  url = 'https://example.com/v1/test'
+): Promise<Headers> {
+  const headers = new Headers();
+  const mockReq = { header: headers, url } as Parameters<ReturnType<Interceptor>>[0];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const mockNext = async (req: any) => req as any;
+  await interceptor(mockNext)(mockReq);
+  return headers;
+}
+
+// --- authTokenInterceptor ---
+
+describe('authTokenInterceptor', () => {
+  it('sets the Authorization header with the token from tokenProvider', async () => {
+    const interceptor = authTokenInterceptor(async () => 'test-token-123');
+    const headers = await captureHeaders(interceptor);
+    expect(headers.get('Authorization')).to.equal('Bearer test-token-123');
+  });
+
+  it('calls tokenProvider on each request', async () => {
+    let callCount = 0;
+    const interceptor = authTokenInterceptor(async () => {
+      callCount++;
+      return `token-${callCount}`;
+    });
+
+    const h1 = await captureHeaders(interceptor);
+    const h2 = await captureHeaders(interceptor);
+
+    expect(h1.get('Authorization')).to.equal('Bearer token-1');
+    expect(h2.get('Authorization')).to.equal('Bearer token-2');
+    expect(callCount).to.equal(2);
+  });
+});
+
+// --- authTokenDPoPInterceptor ---
+
+describe('authTokenDPoPInterceptor', () => {
+  it('sets Authorization, DPoP, and X-VirtruPubKey headers', async () => {
+    const interceptor = authTokenDPoPInterceptor({
+      tokenProvider: async () => 'dpop-token',
+    });
+
+    const headers = await captureHeaders(interceptor);
+
+    expect(headers.get('Authorization')).to.equal('Bearer dpop-token');
+    expect(headers.get('DPoP')).to.be.a('string');
+    expect(headers.get('DPoP')!.split('.')).to.have.length(3); // JWT format
+    expect(headers.get('X-VirtruPubKey')).to.be.a('string');
+    expect(headers.get('X-VirtruPubKey')!.length).to.be.greaterThan(0);
+  });
+
+  it('exposes dpopKeys as a promise that resolves to a KeyPair', async () => {
+    const interceptor = authTokenDPoPInterceptor({
+      tokenProvider: async () => 'token',
+    });
+
+    expect(interceptor.dpopKeys).to.be.instanceOf(Promise);
+    const keys = await interceptor.dpopKeys;
+    expect(keys).to.have.property('publicKey');
+    expect(keys).to.have.property('privateKey');
+  });
+
+  it('uses provided dpopKeys instead of generating new ones', async () => {
+    // Import crypto service to generate known keys
+    const cryptoService = await import('../../tdf3/src/crypto/index.js');
+    const knownKeys = await cryptoService.generateSigningKeyPair();
+
+    const interceptor = authTokenDPoPInterceptor({
+      tokenProvider: async () => 'token',
+      dpopKeys: knownKeys,
+    });
+
+    const resolvedKeys = await interceptor.dpopKeys;
+    expect(resolvedKeys).to.equal(knownKeys);
+  });
+
+  it('generates a valid DPoP proof JWT', async () => {
+    const interceptor = authTokenDPoPInterceptor({
+      tokenProvider: async () => 'test-access-token',
+    });
+
+    const headers = await captureHeaders(interceptor, 'https://example.com/v1/rewrap');
+    const dpopToken = headers.get('DPoP')!;
+
+    // Decode the JWT payload (middle part)
+    const base64UrlDecode = (input: string): string => {
+      let b64 = input.replace(/-/g, '+').replace(/_/g, '/');
+      while (b64.length % 4 !== 0) {
+        b64 += '=';
+      }
+      return atob(b64);
+    };
+    const [headerB64, payloadB64] = dpopToken.split('.');
+    const header = JSON.parse(base64UrlDecode(headerB64));
+    const payload = JSON.parse(base64UrlDecode(payloadB64));
+
+    expect(header.typ).to.equal('dpop+jwt');
+    expect(header.jwk).to.be.an('object');
+    expect(payload.htm).to.equal('POST');
+    expect(payload.htu).to.equal('https://example.com/v1/rewrap');
+    expect(payload.iat).to.be.a('number');
+    expect(payload.jti).to.be.a('string');
+  });
+});
+
+// --- authProviderInterceptor ---
+
+describe('authProviderInterceptor', () => {
+  it('delegates to authProvider.withCreds and applies returned headers', async () => {
+    const mockAuthProvider: AuthProvider = {
+      updateClientPublicKey: async () => {},
+      withCreds: async (req: HttpRequest) =>
+        withHeaders(req, {
+          Authorization: 'Bearer provider-token',
+          'X-Custom': 'custom-value',
+        }),
+    };
+
+    const interceptor = authProviderInterceptor(mockAuthProvider);
+    const headers = await captureHeaders(interceptor);
+
+    expect(headers.get('Authorization')).to.equal('Bearer provider-token');
+    expect(headers.get('X-Custom')).to.equal('custom-value');
+  });
+
+  it('wraps updateClientPublicKey errors with helpful message', async () => {
+    const failingProvider: AuthProvider = {
+      updateClientPublicKey: async () => {},
+      withCreds: async () => {
+        throw new Error('public key not configured');
+      },
+    };
+
+    const interceptor = authProviderInterceptor(failingProvider);
+    try {
+      await captureHeaders(interceptor);
+      expect.fail('should have thrown');
+    } catch (e) {
+      expect((e as Error).message).to.include('DPoP key binding is not complete');
+    }
+  });
+});
+
+// --- resolveInterceptors / resolveAuthConfig / isInterceptorConfig ---
+
+describe('AuthConfig utilities', () => {
+  const stubAuthProvider: AuthProvider = {
+    updateClientPublicKey: async () => {},
+    withCreds: async (req) => req,
+  };
+
+  describe('isInterceptorConfig', () => {
+    it('returns true for interceptor config', () => {
+      const noop: Interceptor = (next) => (req) => next(req);
+      expect(isInterceptorConfig({ interceptors: [noop] })).to.equal(true);
+    });
+
+    it('returns false for AuthProvider', () => {
+      expect(isInterceptorConfig(stubAuthProvider)).to.equal(false);
+    });
+  });
+
+  describe('resolveInterceptors', () => {
+    it('returns interceptors directly from interceptor config', () => {
+      const noop: Interceptor = (next) => (req) => next(req);
+      const result = resolveInterceptors({ interceptors: [noop] });
+      expect(result).to.deep.equal([noop]);
+    });
+
+    it('wraps AuthProvider into an interceptor array', () => {
+      const result = resolveInterceptors(stubAuthProvider);
+      expect(result).to.have.length(1);
+      expect(result[0]).to.be.a('function');
+    });
+  });
+
+  describe('resolveAuthConfig', () => {
+    it('preserves authProvider in the result for AuthProvider input', () => {
+      const result = resolveAuthConfig(stubAuthProvider);
+      expect(result.authProvider).to.equal(stubAuthProvider);
+      expect(result.interceptors).to.have.length(1);
+    });
+
+    it('returns undefined authProvider for interceptor config', () => {
+      const noop: Interceptor = (next) => (req) => next(req);
+      const result = resolveAuthConfig({ interceptors: [noop] });
+      expect(result.authProvider).to.equal(undefined);
+      expect(result.interceptors).to.deep.equal([noop]);
+    });
+  });
+});

--- a/lib/tests/web/opentdf.test.ts
+++ b/lib/tests/web/opentdf.test.ts
@@ -140,12 +140,12 @@ describe('OpenTDF constructor', () => {
       }
     });
 
-    it('passes interceptors to tdf3Client', () => {
+    it('resolves auth config in tdf3Client', () => {
       const client = new OpenTDF({
         interceptors: [stubInterceptor],
         platformUrl: 'https://example.com',
       });
-      expect(client.tdf3Client.interceptors).to.deep.equal([stubInterceptor]);
+      expect(client.tdf3Client.auth).to.deep.equal({ interceptors: [stubInterceptor] });
     });
 
     it('generates dpopKeys even with interceptors', async () => {

--- a/lib/tests/web/opentdf.test.ts
+++ b/lib/tests/web/opentdf.test.ts
@@ -1,6 +1,8 @@
 import { expect } from '@esm-bundle/chai';
 import { OpenTDF } from '../../src/opentdf.js';
 import type { AuthProvider } from '../../src/auth/auth.js';
+import type { Interceptor } from '@connectrpc/connect';
+import { authTokenInterceptor } from '../../src/auth/interceptors.js';
 
 const stubAuthProvider: AuthProvider = {
   updateClientPublicKey: async () => {},
@@ -97,6 +99,62 @@ describe('OpenTDF constructor', () => {
       } catch (e) {
         expect(e).to.have.property('message', 'IdP unreachable');
       }
+    });
+  });
+
+  describe('interceptors (new path)', () => {
+    const stubInterceptor: Interceptor = (next) => (req) => next(req);
+
+    it('accepts interceptors instead of authProvider', () => {
+      const client = new OpenTDF({
+        interceptors: [stubInterceptor],
+        platformUrl: 'https://example.com',
+      });
+      expect(client.interceptors).to.deep.equal([stubInterceptor]);
+      expect(client.authProvider).to.equal(undefined);
+    });
+
+    it('ready resolves immediately with interceptors', async () => {
+      const client = new OpenTDF({
+        interceptors: [stubInterceptor],
+      });
+      // Should not hang or throw
+      await client.ready;
+    });
+
+    it('does not call updateClientPublicKey with interceptors', async () => {
+      const client = new OpenTDF({
+        interceptors: [authTokenInterceptor(async () => 'token')],
+      });
+      await client.ready;
+      // No updateClientPublicKey to call — if we got here, no error was thrown
+      expect(client.dpopEnabled).to.equal(true);
+    });
+
+    it('throws if neither authProvider nor interceptors provided', () => {
+      try {
+        new OpenTDF({});
+        expect.fail('should have thrown');
+      } catch (e) {
+        expect((e as Error).message).to.include('Either authProvider or interceptors');
+      }
+    });
+
+    it('passes interceptors to tdf3Client', () => {
+      const client = new OpenTDF({
+        interceptors: [stubInterceptor],
+        platformUrl: 'https://example.com',
+      });
+      expect(client.tdf3Client.interceptors).to.deep.equal([stubInterceptor]);
+    });
+
+    it('generates dpopKeys even with interceptors', async () => {
+      const client = new OpenTDF({
+        interceptors: [stubInterceptor],
+      });
+      const keys = await client.dpopKeys;
+      expect(keys).to.have.property('publicKey');
+      expect(keys).to.have.property('privateKey');
     });
   });
 });

--- a/lib/tests/web/platform-rpc.test.ts
+++ b/lib/tests/web/platform-rpc.test.ts
@@ -1,5 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { type AuthProvider, HttpRequest, withHeaders } from '../../src/auth/auth.js';
+import { authTokenInterceptor } from '../../src/auth/interceptors.js';
 import { PlatformClient } from '../../src/platform.js';
 import { attributeFQNsAsValues } from '../../src/policy/api.js';
 import { fetchWrappedKey } from '../../src/access/access-rpc.js';
@@ -148,6 +149,73 @@ describe('Local Platform Connect RPC Client Tests', () => {
       }
     } catch (e) {
       console.log(e);
+    }
+  });
+});
+
+describe('PlatformClient with interceptors (no authProvider)', () => {
+  const dummyToken =
+    'dummy-auth-token eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZGYiLCJzdWIiOiJKb2huIERvZSIsImlhdCI6MTUxNjIzOTAyMn0.XFu4sQxAd6n-b7urqTdQ-I9zKqKSQtC04unHsMSpJjc';
+
+  it('wellknown configuration via interceptor', async () => {
+    const platform = new PlatformClient({
+      interceptors: [authTokenInterceptor(async () => dummyToken)],
+      platformUrl,
+    });
+
+    try {
+      const response = await platform.v1.wellknown.getWellKnownConfiguration({});
+      expect(response.$typeName).to.equal(
+        'wellknownconfiguration.GetWellKnownConfigurationResponse'
+      );
+    } catch (e) {
+      expect.fail('Test failed', e);
+    }
+  });
+
+  it('policy attribute method via interceptor', async () => {
+    const platform = new PlatformClient({
+      interceptors: [authTokenInterceptor(async () => dummyToken)],
+      platformUrl,
+    });
+
+    try {
+      const response = await platform.v1.attributes.listAttributes({});
+      expect(response.$typeName).to.equal('policy.attributes.ListAttributesResponse');
+    } catch (e) {
+      expect.fail('Test failed', e);
+    }
+  });
+
+  it('attributeFQNsAsValues via interceptor auth config', async () => {
+    const fqns = ['https://granted.ns/attr/granted/value/granted'];
+
+    try {
+      const response = await attributeFQNsAsValues(
+        platformUrl,
+        { interceptors: [authTokenInterceptor(async () => dummyToken)] },
+        ...fqns
+      );
+      expect(response[0].$typeName).to.equal('policy.Value');
+    } catch (e) {
+      expect.fail('Test failed', e);
+    }
+  });
+
+  it('rewrap key via interceptor', async () => {
+    const platform = new PlatformClient({
+      interceptors: [authTokenInterceptor(async () => dummyToken)],
+      platformUrl,
+    });
+
+    try {
+      const response = await platform.v1.access.rewrap({
+        signedRequestToken:
+          'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJyZXF1ZXN0Qm9keSI6Im1vY2stcmVxdWVzdC1ib2R5In0.0O9eyg-zC5Ztf78mPaa61n6INtpTdJv6iQQ_3tg2TRlzA73Md-JDTedGKwQ_J6QQycR5AMY5UqrsQvkcK50jfQ',
+      });
+      expect(response.$typeName).to.equal('kas.RewrapResponse');
+    } catch (e) {
+      expect.fail('Test failed', e);
     }
   });
 });


### PR DESCRIPTION
Unifies auth for both PlatformClient and OpenTDF on the Connect RPC Interceptor pattern, eliminating the updateClientPublicKey footgun and the dual-abstraction complexity before 1.0.

- Add authTokenInterceptor, authTokenDPoPInterceptor, authProviderInterceptor helpers
- Introduce AuthConfig union type (AuthProvider | { interceptors }) throughout
- OpenTDF and PlatformClient accept interceptors as the primary auth mechanism
- Thread interceptors through TDF3Client, tdf.ts, access, and policy layers
- AuthProvider remains fully supported as backwards-compatible (deprecated)
- Legacy fetch fallback preserved when AuthProvider is used
- Update README with interceptor-first examples

Discussion: https://github.com/orgs/opentdf/discussions/3167


## What we gain:

- Single auth pattern — both PlatformClient and OpenTDF use interceptors, no more two mental models
- Kill the updateClientPublicKey footgun — no more hidden ordering requirement where you must await client.ready before PlatformClient works
- DPoP becomes explicit — opt-in via authTokenDPoPInterceptor() instead of a side effect buried in AccessToken internals
- Remove the bridge layer — createAuthInterceptor (the AuthProvider-to-Interceptor wrapper in platform.ts) goes away as production code, only needed for backwards compat
- Simpler standalone PlatformClient usage — no need to construct an OpenTDF first just to get auth working
- Bring-your-own-auth becomes trivial — users behind a proxy or with custom auth just write a 3-line interceptor, no need to implement the AuthProvider interface
- Smaller public API surface for 1.0 — fewer types to commit to supporting forever
- Aligns with Connect RPC idioms — interceptors are the native pattern for @connectrpc/connect-web, so we stop fighting the framework
- Testability — interceptors are plain functions, easier to test and mock than stateful AuthProvider instances with internal token caches
- 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interceptor-based auth is now supported across SDK surfaces; token and DPoP interceptors exported and preferred. Legacy auth-provider path is deprecated but retained for compatibility.

* **Documentation**
  * README updated with “With Interceptors (Recommended)” examples, DPoP usage, custom-interceptor guidance, and legacy approach moved under “(Legacy)”.

* **Tests**
  * Added tests for token & DPoP interceptors, DPoP proof contents, and interceptor-only client behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
