### PR TITLE
fix(ci): allow main scope in PR title validation

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -14,6 +14,6 @@ on:
 
 jobs:
   build-and-test:
-    uses: opentdf/web-sdk/.github/workflows/reusable_build-and-test.yaml@main
+    uses: ./.github/workflows/reusable_build-and-test.yaml
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -14,6 +14,6 @@ on:
 
 jobs:
   build-and-test:
-    uses: ./.github/workflows/reusable_build-and-test.yaml
+    uses: opentdf/web-sdk/.github/workflows/reusable_build-and-test.yaml@main
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/reusable_build-and-test.yaml
+++ b/.github/workflows/reusable_build-and-test.yaml
@@ -42,10 +42,12 @@ jobs:
           #   - ci: anything related to ci
           #   - tests: test only changes
           #   - docs: anything related solely to documentation
+          #   - main: release-please release PRs
           scopes: |
             ci
             cli
             docs
+            main
             sdk
             tests
 


### PR DESCRIPTION
## Summary

- Adds `main` to the allowed scopes in the Conventional Commits Check
- Fixes `build-and-test / ccc` check failing on release-please PRs (e.g. #900)

Release-please uses `chore(main): release sdk ${version}` for PR titles, but `main` was not in the allowed scopes list.

## Test plan

- [x] Verify this PR's own `ccc` check passes
- [ ] Confirm #900 passes after this merges (or re-run its check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)