### PR TITLE
fix(ci): remove redundant npm install in dev-artifact workflow

### DIFF
--- a/.github/workflows/dev-artifact.yaml
+++ b/.github/workflows/dev-artifact.yaml
@@ -27,7 +27,6 @@ jobs:
       - name: Build CLI
         working-directory: ./cli
         run: |
-          npm install
           npm install ../lib/opentdf-sdk-*.tgz
           npm run build
           npm pack


### PR DESCRIPTION
## Summary
- The "Build CLI" step in the [dev-artifact workflow](https://github.com/opentdf/web-sdk/actions/workflows/dev-artifact.yaml) runs `npm install` before `npm install ../lib/opentdf-sdk-*.tgz`. The bare `npm install` resolves the lockfile's `file:` reference to the SDK tarball and checks the integrity hash from the lockfile. Since the tarball is freshly built from the current commit, the hash doesn't match, causing the build to fail with `EINTEGRITY`.
- This has been the pattern after every SDK release — the workflow works on the release commit (when the lockfile hash matches the tarball), then fails on every subsequent push to main until the next release.
- Removes the redundant `npm install` so `npm install ../lib/opentdf-sdk-*.tgz` handles all deps and the fresh tarball in one step.

## Impact
- The `dev` GitHub pre-release is stale — it's stuck at the last SDK release instead of tracking the latest main.
- No impact on npm publishing, PR CI, or merge gating. This workflow only runs on push to main and only publishes a GitHub pre-release artifact.

## Test plan
- [ ] Merge and confirm the dev-artifact workflow passes on the next push to main
- [ ] Verify the `dev` GitHub release is updated with a fresh CLI tarball

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized the build workflow process to streamline dependency installation and package generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->