### PR TITLE
feat(sdk): namespace EntityIdentifier helpers under EntityIdentifiers

### DIFF
--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -19,13 +19,7 @@ export {
   type ExternalJwtTokenProviderOptions,
 } from './auth/token-providers.js';
 export { attributeFQNsAsValues } from './policy/api.js';
-export {
-  forEmail,
-  forClientId,
-  forUserName,
-  forToken,
-  withRequestToken,
-} from './platform/authorization/entity-identifiers.js';
+export * as EntityIdentifiers from './platform/authorization/entity-identifiers.js';
 export {
   listAttributes,
   validateAttributes,

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -20,6 +20,16 @@ export {
 } from './auth/token-providers.js';
 export { attributeFQNsAsValues } from './policy/api.js';
 export * as EntityIdentifiers from './platform/authorization/entity-identifiers.js';
+/** @deprecated Use `EntityIdentifiers.forEmail()` instead. Will be removed in a future release. */
+export { forEmail } from './platform/authorization/entity-identifiers.js';
+/** @deprecated Use `EntityIdentifiers.forClientId()` instead. Will be removed in a future release. */
+export { forClientId } from './platform/authorization/entity-identifiers.js';
+/** @deprecated Use `EntityIdentifiers.forUserName()` instead. Will be removed in a future release. */
+export { forUserName } from './platform/authorization/entity-identifiers.js';
+/** @deprecated Use `EntityIdentifiers.forToken()` instead. Will be removed in a future release. */
+export { forToken } from './platform/authorization/entity-identifiers.js';
+/** @deprecated Use `EntityIdentifiers.withRequestToken()` instead. Will be removed in a future release. */
+export { withRequestToken } from './platform/authorization/entity-identifiers.js';
 export {
   listAttributes,
   validateAttributes,

--- a/lib/src/platform/authorization/entity-identifiers.ts
+++ b/lib/src/platform/authorization/entity-identifiers.ts
@@ -35,7 +35,8 @@ import {
  * });
  *
  * // After
- * const eid = forEmail('jen@example.com');
+ * import { EntityIdentifiers } from '@opentdf/sdk';
+ * const eid = EntityIdentifiers.forEmail('jen@example.com');
  * ```
  */
 

--- a/lib/tests/mocha/unit/entity-identifiers.spec.ts
+++ b/lib/tests/mocha/unit/entity-identifiers.spec.ts
@@ -1,11 +1,5 @@
 import { expect } from 'chai';
-import {
-  forEmail,
-  forClientId,
-  forUserName,
-  forToken,
-  withRequestToken,
-} from '../../../src/index.js';
+import { EntityIdentifiers } from '../../../src/index.js';
 import { Entity_Category } from '../../../src/platform/entity/entity_pb.js';
 import type { EntityChain, Token } from '../../../src/platform/entity/entity_pb.js';
 import type { BoolValue } from '@bufbuild/protobuf/wkt';
@@ -14,7 +8,7 @@ describe('EntityIdentifier helpers', () => {
   describe('forEmail()', () => {
     for (const email of ['user@example.com', '']) {
       it(`builds an entityChain with emailAddress="${email}"`, () => {
-        const eid = forEmail(email);
+        const eid = EntityIdentifiers.forEmail(email);
         expect(eid.identifier.case).to.equal('entityChain');
         const chain = eid.identifier.value as EntityChain;
         expect(chain.entities).to.have.lengthOf(1);
@@ -29,7 +23,7 @@ describe('EntityIdentifier helpers', () => {
   describe('forClientId()', () => {
     for (const clientId of ['my-client', '']) {
       it(`builds an entityChain with clientId="${clientId}"`, () => {
-        const eid = forClientId(clientId);
+        const eid = EntityIdentifiers.forClientId(clientId);
         expect(eid.identifier.case).to.equal('entityChain');
         const chain = eid.identifier.value as EntityChain;
         expect(chain.entities).to.have.lengthOf(1);
@@ -44,7 +38,7 @@ describe('EntityIdentifier helpers', () => {
   describe('forUserName()', () => {
     for (const userName of ['alice', '']) {
       it(`builds an entityChain with userName="${userName}"`, () => {
-        const eid = forUserName(userName);
+        const eid = EntityIdentifiers.forUserName(userName);
         expect(eid.identifier.case).to.equal('entityChain');
         const chain = eid.identifier.value as EntityChain;
         expect(chain.entities).to.have.lengthOf(1);
@@ -59,7 +53,7 @@ describe('EntityIdentifier helpers', () => {
   describe('forToken()', () => {
     for (const jwt of ['eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.test', '']) {
       it(`builds a token identifier with jwt="${jwt.slice(0, 20)}..."`, () => {
-        const eid = forToken(jwt);
+        const eid = EntityIdentifiers.forToken(jwt);
         expect(eid.identifier.case).to.equal('token');
         expect((eid.identifier.value as Token).jwt).to.equal(jwt);
       });
@@ -68,7 +62,7 @@ describe('EntityIdentifier helpers', () => {
 
   describe('withRequestToken()', () => {
     it('builds a withRequestToken identifier set to true', () => {
-      const eid = withRequestToken();
+      const eid = EntityIdentifiers.withRequestToken();
       expect(eid.identifier.case).to.equal('withRequestToken');
       expect((eid.identifier.value as BoolValue).value).to.equal(true);
     });


### PR DESCRIPTION
## Summary
- Export `EntityIdentifier` convenience constructors under a namespaced `EntityIdentifiers` object, using the existing `export * as` pattern (same as `AuthProviders`)
- Bare named exports (`forEmail`, `forClientId`, etc.) are preserved with `@deprecated` JSDoc tags for backwards compatibility
- Aligns with the Java SDK's `EntityIdentifiers.forEmail(...)` pattern
- Avoids top-level name collisions with future SDK features (e.g. TDF recipient helpers)

### Migration

```typescript
// Old (still works, but deprecated)
import { forEmail } from '@opentdf/sdk';
forEmail('alice@example.com');

// New (recommended)
import { EntityIdentifiers } from '@opentdf/sdk';
EntityIdentifiers.forEmail('alice@example.com');
```

Closes #915

## Test plan
- [x] All 9 EntityIdentifier unit tests pass with namespaced imports
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)