### PR TITLE
fix(sdk): bound browser decrypt memory for large chunker downloads

### DIFF
--- a/lib/tdf3/src/ciphers/aes-gcm-cipher.ts
+++ b/lib/tdf3/src/ciphers/aes-gcm-cipher.ts
@@ -75,10 +75,9 @@ export class AesGcmCipher extends SymmetricCipher {
       );
     }
 
-    const { payload, payloadIv } = processGcmPayload(buffer.buffer.slice(
-      buffer.byteOffset,
-      buffer.byteOffset + buffer.byteLength
-    ));
+    const { payload, payloadIv } = processGcmPayload(
+      buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength)
+    );
 
     return this.cryptoService.decrypt(payload, key, payloadIv, Algorithms.AES_256_GCM);
   }

--- a/lib/tdf3/src/ciphers/aes-gcm-cipher.ts
+++ b/lib/tdf3/src/ciphers/aes-gcm-cipher.ts
@@ -62,21 +62,23 @@ export class AesGcmCipher extends SymmetricCipher {
    */
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   override async decrypt(
-    buffer: Uint8Array,
+    buffer: ArrayBuffer | Uint8Array,
     key: SymmetricKey,
     iv?: Binary
   ): Promise<DecryptResult> {
+    const input = buffer instanceof Uint8Array ? buffer : new Uint8Array(buffer);
+
     if (this.cryptoService.name === 'BrowserNativeCryptoService') {
       return decryptBufferSource(
-        buffer.subarray(12),
+        input.subarray(12),
         key,
-        buffer.subarray(0, 12),
+        input.subarray(0, 12),
         Algorithms.AES_256_GCM
       );
     }
 
     const { payload, payloadIv } = processGcmPayload(
-      buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength)
+      input.buffer.slice(input.byteOffset, input.byteOffset + input.byteLength)
     );
 
     return this.cryptoService.decrypt(payload, key, payloadIv, Algorithms.AES_256_GCM);

--- a/lib/tdf3/src/ciphers/aes-gcm-cipher.ts
+++ b/lib/tdf3/src/ciphers/aes-gcm-cipher.ts
@@ -1,6 +1,7 @@
 import { Binary } from '../binary.js';
 import { Algorithms } from './algorithms.js';
 import { SymmetricCipher } from './symmetric-cipher-base.js';
+import { decryptBufferSource } from '../crypto/core/symmetric.js';
 import { concatUint8 } from '../utils/index.js';
 
 import {
@@ -16,20 +17,17 @@ const IV_LENGTH = 12;
 type ProcessGcmPayload = {
   payload: Binary;
   payloadIv: Binary;
-  payloadAuthTag: Binary;
 };
 // Should this be a Binary, Buffer, or... both?
 function processGcmPayload(source: ArrayBuffer): ProcessGcmPayload {
   // Read the 12 byte IV from the beginning of the stream
   const payloadIv = Binary.fromArrayBuffer(source.slice(0, 12));
 
-  // Slice the final 16 bytes of the buffer for the authentication tag
-  const payloadAuthTag = Binary.fromArrayBuffer(source.slice(-16));
-
   return {
-    payload: Binary.fromArrayBuffer(source.slice(12, -16)),
+    // WebCrypto AES-GCM expects ciphertext with the auth tag appended, so keep
+    // the tag attached instead of splitting and re-concatenating it later.
+    payload: Binary.fromArrayBuffer(source.slice(12)),
     payloadIv,
-    payloadAuthTag,
   };
 }
 
@@ -64,18 +62,24 @@ export class AesGcmCipher extends SymmetricCipher {
    */
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   override async decrypt(
-    buffer: ArrayBuffer,
+    buffer: Uint8Array,
     key: SymmetricKey,
     iv?: Binary
   ): Promise<DecryptResult> {
-    const { payload, payloadIv, payloadAuthTag } = processGcmPayload(buffer);
+    if (this.cryptoService.name === 'BrowserNativeCryptoService') {
+      return decryptBufferSource(
+        buffer.subarray(12),
+        key,
+        buffer.subarray(0, 12),
+        Algorithms.AES_256_GCM
+      );
+    }
 
-    return this.cryptoService.decrypt(
-      payload,
-      key,
-      payloadIv,
-      Algorithms.AES_256_GCM,
-      payloadAuthTag
-    );
+    const { payload, payloadIv } = processGcmPayload(buffer.buffer.slice(
+      buffer.byteOffset,
+      buffer.byteOffset + buffer.byteLength
+    ));
+
+    return this.cryptoService.decrypt(payload, key, payloadIv, Algorithms.AES_256_GCM);
   }
 }

--- a/lib/tdf3/src/ciphers/symmetric-cipher-base.ts
+++ b/lib/tdf3/src/ciphers/symmetric-cipher-base.ts
@@ -37,5 +37,9 @@ export abstract class SymmetricCipher {
 
   abstract encrypt(payload: Binary, key: SymmetricKey, iv: Binary): Promise<EncryptResult>;
 
-  abstract decrypt(payload: Uint8Array, key: SymmetricKey, iv?: Binary): Promise<DecryptResult>;
+  abstract decrypt(
+    payload: ArrayBuffer | Uint8Array,
+    key: SymmetricKey,
+    iv?: Binary
+  ): Promise<DecryptResult>;
 }

--- a/lib/tdf3/src/crypto/core/symmetric.ts
+++ b/lib/tdf3/src/crypto/core/symmetric.ts
@@ -13,6 +13,16 @@ import { unwrapSymmetricKey, wrapSymmetricKey } from './keys.js';
 
 const ENC_DEC_METHODS: KeyUsage[] = ['encrypt', 'decrypt'];
 
+function asUint8ArrayView(buffer: BufferSource): Uint8Array {
+  if (buffer instanceof Uint8Array) {
+    return buffer;
+  }
+  if (ArrayBuffer.isView(buffer)) {
+    return new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength);
+  }
+  return new Uint8Array(buffer);
+}
+
 /**
  * Generate a random symmetric key (opaque).
  * @param length - Key length in bytes (default 32 for AES-256)
@@ -61,7 +71,23 @@ export function decrypt(
   algorithm?: AlgorithmUrn,
   authTag?: Binary
 ): Promise<DecryptResult> {
-  return _doDecrypt(payload, key, iv, algorithm, authTag);
+  return _doDecryptBufferSource(
+    payload.asArrayBuffer(),
+    key,
+    iv.asArrayBuffer(),
+    algorithm,
+    authTag?.asArrayBuffer()
+  );
+}
+
+export function decryptBufferSource(
+  payload: BufferSource,
+  key: SymmetricKey,
+  iv: BufferSource,
+  algorithm?: AlgorithmUrn,
+  authTag?: BufferSource
+): Promise<DecryptResult> {
+  return _doDecryptBufferSource(payload, key, iv, algorithm, authTag);
 }
 
 /**
@@ -115,32 +141,34 @@ async function _doEncrypt(
   };
 }
 
-async function _doDecrypt(
-  payload: Binary,
+async function _doDecryptBufferSource(
+  payload: BufferSource,
   key: SymmetricKey,
-  iv: Binary,
+  iv: BufferSource,
   algorithm?: AlgorithmUrn,
-  authTag?: Binary
+  authTag?: BufferSource
 ): Promise<DecryptResult> {
   console.assert(payload != null);
   console.assert(key != null);
   console.assert(iv != null);
 
-  let payloadBuffer = payload.asArrayBuffer();
+  let payloadBuffer: BufferSource = payload;
 
   // Concat the the auth tag to the payload for decryption
   if (authTag) {
-    const authTagBuffer = authTag.asArrayBuffer();
-    const gcmPayload = new Uint8Array(payloadBuffer.byteLength + authTagBuffer.byteLength);
-    gcmPayload.set(new Uint8Array(payloadBuffer), 0);
-    gcmPayload.set(new Uint8Array(authTagBuffer), payloadBuffer.byteLength);
-    payloadBuffer = gcmPayload.buffer;
+    const payloadBytes = asUint8ArrayView(payloadBuffer);
+    const authTagBytes = asUint8ArrayView(authTag);
+    const gcmPayload = new Uint8Array(payloadBytes.byteLength + authTagBytes.byteLength);
+    gcmPayload.set(payloadBytes, 0);
+    gcmPayload.set(authTagBytes, payloadBytes.byteLength);
+    payloadBuffer = gcmPayload;
   }
 
-  const algoDomString = getSymmetricAlgoDomString(iv, algorithm);
+  const ivBytes = asUint8ArrayView(iv);
+  const algoDomString = getSymmetricAlgoDomStringFromIv(ivBytes, algorithm);
   const keyBytes = unwrapSymmetricKey(key);
   const importedKey = await _importKey(keyBytes, algoDomString);
-  algoDomString.iv = iv.asArrayBuffer();
+  algoDomString.iv = ivBytes;
 
   const decrypted = await crypto.subtle
     .decrypt(algoDomString, importedKey, payloadBuffer)
@@ -169,6 +197,13 @@ function getSymmetricAlgoDomString(
   iv: Binary,
   algorithm?: AlgorithmUrn
 ): AesCbcParams | AesGcmParams {
+  return getSymmetricAlgoDomStringFromIv(asUint8ArrayView(iv.asArrayBuffer()), algorithm);
+}
+
+function getSymmetricAlgoDomStringFromIv(
+  iv: Uint8Array,
+  algorithm?: AlgorithmUrn
+): AesCbcParams | AesGcmParams {
   let nativeAlgorithm = 'AES-CBC';
   if (algorithm === Algorithms.AES_256_GCM) {
     nativeAlgorithm = 'AES-GCM';
@@ -176,7 +211,7 @@ function getSymmetricAlgoDomString(
 
   return {
     name: nativeAlgorithm,
-    iv: iv.asArrayBuffer(),
+    iv,
   };
 }
 

--- a/lib/tdf3/src/crypto/core/symmetric.ts
+++ b/lib/tdf3/src/crypto/core/symmetric.ts
@@ -168,7 +168,6 @@ async function _doDecryptBufferSource(
   const algoDomString = getSymmetricAlgoDomStringFromIv(ivBytes, algorithm);
   const keyBytes = unwrapSymmetricKey(key);
   const importedKey = await _importKey(keyBytes, algoDomString);
-  algoDomString.iv = ivBytes;
 
   const decrypted = await crypto.subtle
     .decrypt(algoDomString, importedKey, payloadBuffer)

--- a/lib/tdf3/src/models/encryption-information.ts
+++ b/lib/tdf3/src/models/encryption-information.ts
@@ -72,7 +72,7 @@ export class SplitKey {
     return this.cipher.encrypt(contentBinary, key, ivBinary);
   }
 
-  async decrypt(content: Uint8Array, key: SymmetricKey): Promise<DecryptResult> {
+  async decrypt(content: ArrayBuffer | Uint8Array, key: SymmetricKey): Promise<DecryptResult> {
     return this.cipher.decrypt(content, key);
   }
 

--- a/lib/tdf3/src/tdf.ts
+++ b/lib/tdf3/src/tdf.ts
@@ -138,7 +138,6 @@ function mailbox<T>(): Mailbox<T> {
 
 type Chunk = {
   hash: string;
-  index?: number;
   plainSegmentSize?: number;
   encryptedOffset: number;
   encryptedSegmentSize?: number;
@@ -146,30 +145,6 @@ type Chunk = {
 };
 
 export type IntegrityAlgorithm = 'GMAC' | 'HS256';
-
-function logLargeDecryptDebug(event: string, details: Record<string, unknown>) {
-  console.debug(`[opentdf][decrypt-debug] ${event}`, details);
-}
-
-function getBinaryStorageType(payload: DecryptResult['payload']) {
-  if (payload.isArrayBuffer()) {
-    return 'ArrayBuffer';
-  }
-  if (payload.isByteArray()) {
-    return 'ByteArray';
-  }
-  if (payload.isString()) {
-    return 'String';
-  }
-  return 'Unknown';
-}
-
-function shouldLogTailSegment(index: number | undefined, totalSegmentCount: number | undefined) {
-  if (index === undefined || totalSegmentCount === undefined) {
-    return false;
-  }
-  return index >= Math.max(0, totalSegmentCount - 32);
-}
 
 export type EncryptConfiguration = {
   allowList?: OriginAllowList;
@@ -1062,9 +1037,6 @@ async function updateChunkQueue(
         cryptoService,
         specVersion,
         slice: chunks.slice(i, i + LEGACY_SEGMENTS_PER_DOWNLOAD),
-        sliceEndIndex: Math.min(chunks.length, i + LEGACY_SEGMENTS_PER_DOWNLOAD),
-        sliceStartIndex: i,
-        totalSegmentCount: chunks.length,
       }).catch(() => undefined)
     );
   }
@@ -1092,9 +1064,6 @@ async function fetchAndDecryptChunkSlice({
   cryptoService,
   specVersion,
   slice,
-  sliceEndIndex,
-  sliceStartIndex,
-  totalSegmentCount,
 }: {
   centralDirectory: CentralDirectory[];
   zipReader: ZipReader;
@@ -1104,30 +1073,13 @@ async function fetchAndDecryptChunkSlice({
   cryptoService: CryptoService;
   specVersion: string;
   slice: Chunk[];
-  sliceEndIndex?: number;
-  sliceStartIndex?: number;
-  totalSegmentCount?: number;
 }) {
   const firstChunk = slice[0];
-  const lastChunk = slice[slice.length - 1];
-  const encryptedSegmentSizes = slice.map(({ encryptedSegmentSize }) => encryptedSegmentSize);
-  const plainSegmentSizes = slice.map(({ plainSegmentSize }) => plainSegmentSize);
   let buffer!: Uint8Array;
   const bufferSize = slice.reduce(
     (currentVal, { encryptedSegmentSize }) => currentVal + (encryptedSegmentSize as number),
     0
   );
-  logLargeDecryptDebug('fetch-slice:start', {
-    sliceLength: slice.length,
-    firstSegmentIndex: sliceStartIndex ?? firstChunk.index,
-    lastSegmentIndex:
-      sliceEndIndex !== undefined ? sliceEndIndex - 1 : lastChunk.index,
-    firstEncryptedOffset: firstChunk.encryptedOffset,
-    lastEncryptedOffset: lastChunk.encryptedOffset,
-    bufferSize,
-    encryptedSegmentSizes,
-    plainSegmentSizes,
-  });
   try {
     buffer = await zipReader.getPayloadSegment(
       centralDirectory,
@@ -1135,28 +1087,11 @@ async function fetchAndDecryptChunkSlice({
       firstChunk.encryptedOffset,
       bufferSize
     );
-    logLargeDecryptDebug('fetch-slice:complete', {
-      sliceLength: slice.length,
-      firstSegmentIndex: sliceStartIndex ?? firstChunk.index,
-      lastSegmentIndex:
-        sliceEndIndex !== undefined ? sliceEndIndex - 1 : lastChunk.index,
-      bufferSize,
-      actualReturnedBufferLength: buffer.length,
-    });
   } catch (error) {
     const wrappedError =
       error instanceof InvalidFileError
         ? error
         : new NetworkError('unable to fetch payload segment', error);
-    logLargeDecryptDebug('fetch-slice:error', {
-      sliceLength: slice.length,
-      firstSegmentIndex: sliceStartIndex ?? firstChunk.index,
-      lastSegmentIndex:
-        sliceEndIndex !== undefined ? sliceEndIndex - 1 : lastChunk.index,
-      bufferSize,
-      errorName: wrappedError.name,
-      errorMessage: wrappedError.message,
-    });
     rejectChunks(slice, wrappedError);
     throw wrappedError;
   }
@@ -1170,20 +1105,9 @@ async function fetchAndDecryptChunkSlice({
       cipher,
       segmentIntegrityAlgorithm,
       specVersion,
-      totalSegmentCount,
     });
   } catch (error) {
     const wrappedError = asDecryptError(error, 'failed to decrypt payload segment');
-    logLargeDecryptDebug('decrypt-slice:error', {
-      sliceLength: slice.length,
-      firstSegmentIndex: sliceStartIndex ?? firstChunk.index,
-      lastSegmentIndex:
-        sliceEndIndex !== undefined ? sliceEndIndex - 1 : lastChunk.index,
-      bufferSize,
-      actualReturnedBufferLength: buffer.length,
-      errorName: wrappedError.name,
-      errorMessage: wrappedError.message,
-    });
     rejectChunks(slice, wrappedError);
     throw wrappedError;
   }
@@ -1335,7 +1259,6 @@ export async function sliceAndDecrypt({
   cryptoService,
   segmentIntegrityAlgorithm,
   specVersion,
-  totalSegmentCount,
 }: {
   buffer: Uint8Array;
   reconstructedKey: SymmetricKey;
@@ -1344,20 +1267,7 @@ export async function sliceAndDecrypt({
   cryptoService: CryptoService;
   segmentIntegrityAlgorithm: IntegrityAlgorithm;
   specVersion: string;
-  totalSegmentCount?: number;
 }) {
-  const firstChunk = slice[0];
-  const lastChunk = slice[slice.length - 1];
-  logLargeDecryptDebug('decrypt-slice:start', {
-    sliceLength: slice.length,
-    firstSegmentIndex: firstChunk.index,
-    lastSegmentIndex: lastChunk.index,
-    firstEncryptedOffset: firstChunk.encryptedOffset,
-    lastEncryptedOffset: lastChunk.encryptedOffset,
-    bufferLength: buffer.length,
-    encryptedSegmentSizes: slice.map(({ encryptedSegmentSize }) => encryptedSegmentSize),
-    plainSegmentSizes: slice.map(({ plainSegmentSize }) => plainSegmentSize),
-  });
   for (const index in slice) {
     const chunk = slice[index];
     const { encryptedOffset, encryptedSegmentSize, plainSegmentSize } = chunk;
@@ -1371,20 +1281,6 @@ export async function sliceAndDecrypt({
     }
 
     try {
-      if (shouldLogTailSegment(chunk.index, totalSegmentCount)) {
-        logLargeDecryptDebug('decrypt-segment:start', {
-          sliceLength: slice.length,
-          firstSegmentIndex: firstChunk.index,
-          lastSegmentIndex: lastChunk.index,
-          segmentIndex: chunk.index,
-          segmentOffsetWithinSlice: offset,
-          encryptedOffset,
-          encryptedSegmentSize,
-          plainSegmentSize,
-          bufferLength: buffer.length,
-          encryptedChunkLength: encryptedChunk.length,
-        });
-      }
       const result = await decryptChunk(
         encryptedChunk,
         reconstructedKey,
@@ -1399,36 +1295,8 @@ export async function sliceAndDecrypt({
           `incorrect segment size: found [${result.payload.length()}], expected [${plainSegmentSize}]`
         );
       }
-      if (shouldLogTailSegment(chunk.index, totalSegmentCount)) {
-        logLargeDecryptDebug('decrypt-segment:complete', {
-          sliceLength: slice.length,
-          firstSegmentIndex: firstChunk.index,
-          lastSegmentIndex: lastChunk.index,
-          segmentIndex: chunk.index,
-          segmentOffsetWithinSlice: offset,
-          encryptedOffset,
-          encryptedSegmentSize,
-          plainSegmentSize,
-          payloadLength: result.payload.length(),
-          payloadStorageType: getBinaryStorageType(result.payload),
-        });
-      }
       chunk.decryptedChunk.set(result);
     } catch (e) {
-      logLargeDecryptDebug('decrypt-segment:error', {
-        sliceLength: slice.length,
-        firstSegmentIndex: firstChunk.index,
-        lastSegmentIndex: lastChunk.index,
-        segmentIndex: chunk.index,
-        segmentOffsetWithinSlice: offset,
-        encryptedOffset,
-        encryptedSegmentSize,
-        plainSegmentSize,
-        bufferLength: buffer.length,
-        encryptedChunkLength: encryptedChunk.length,
-        errorName: e instanceof Error ? e.name : typeof e,
-        errorMessage: e instanceof Error ? e.message : String(e),
-      });
       chunk.decryptedChunk.reject(e);
     }
   }
@@ -1538,10 +1406,9 @@ export async function decryptStreamFrom(
       hash,
       encryptedSegmentSize = encryptedSegmentSizeDefault,
       segmentSize = segmentSizeDefault,
-    }, index) => {
+    }) => {
       const chunk: Chunk = {
         hash,
-        index,
         encryptedOffset: mapOfRequestsOffset,
         encryptedSegmentSize,
         decryptedChunk: mailbox<DecryptResult>(),
@@ -1577,9 +1444,6 @@ export async function decryptStreamFrom(
           cryptoService: cfg.cryptoService,
           specVersion,
           slice: chunks.slice(startIndex, endIndex),
-          sliceEndIndex: endIndex,
-          sliceStartIndex: startIndex,
-          totalSegmentCount: chunks.length,
         }),
     });
     scheduler.fillWindow();
@@ -1601,10 +1465,6 @@ export async function decryptStreamFrom(
   const underlyingSource = {
     pull: async (controller: ReadableStreamDefaultController) => {
       if (nextChunkIndex >= chunks.length) {
-        logLargeDecryptDebug('stream-enqueue:complete', {
-          totalSegments: chunks.length,
-          totalEncryptedProgress: progress,
-        });
         controller.close();
         return;
       }
@@ -1612,40 +1472,7 @@ export async function decryptStreamFrom(
       const chunk = chunks[nextChunkIndex];
       const decryptedSegment = await chunk.decryptedChunk;
       const encryptedSegmentSize = chunk.encryptedSegmentSize ?? 0;
-      const payloadStorageType = getBinaryStorageType(decryptedSegment.payload);
-      let plainChunk: Uint8Array;
-      try {
-        plainChunk = new Uint8Array(decryptedSegment.payload.asArrayBuffer());
-      } catch (error) {
-        logLargeDecryptDebug('stream-enqueue:error', {
-          chunkIndex: chunk.index,
-          encryptedOffset: chunk.encryptedOffset,
-          encryptedSegmentSize,
-          plainSegmentSize: chunk.plainSegmentSize,
-          payloadLength: decryptedSegment.payload.length(),
-          payloadStorageType,
-          progress,
-          errorName: error instanceof Error ? error.name : typeof error,
-          errorMessage: error instanceof Error ? error.message : String(error),
-        });
-        throw error;
-      }
-
-      if (
-        chunk.index === 0 ||
-        chunk.index === chunks.length - 1 ||
-        (chunk.index !== undefined && chunk.index >= chunks.length - 4)
-      ) {
-        logLargeDecryptDebug('stream-enqueue:chunk', {
-          chunkIndex: chunk.index,
-          encryptedOffset: chunk.encryptedOffset,
-          encryptedSegmentSize,
-          plainSegmentSize: chunk.plainSegmentSize,
-          payloadLength: decryptedSegment.payload.length(),
-          payloadStorageType,
-          progress,
-        });
-      }
+      const plainChunk = new Uint8Array(decryptedSegment.payload.asArrayBuffer());
 
       controller.enqueue(plainChunk);
       progress += encryptedSegmentSize;

--- a/lib/tdf3/src/tdf.ts
+++ b/lib/tdf3/src/tdf.ts
@@ -138,6 +138,7 @@ function mailbox<T>(): Mailbox<T> {
 
 type Chunk = {
   hash: string;
+  index?: number;
   plainSegmentSize?: number;
   encryptedOffset: number;
   encryptedSegmentSize?: number;
@@ -145,6 +146,30 @@ type Chunk = {
 };
 
 export type IntegrityAlgorithm = 'GMAC' | 'HS256';
+
+function logLargeDecryptDebug(event: string, details: Record<string, unknown>) {
+  console.debug(`[opentdf][decrypt-debug] ${event}`, details);
+}
+
+function getBinaryStorageType(payload: DecryptResult['payload']) {
+  if (payload.isArrayBuffer()) {
+    return 'ArrayBuffer';
+  }
+  if (payload.isByteArray()) {
+    return 'ByteArray';
+  }
+  if (payload.isString()) {
+    return 'String';
+  }
+  return 'Unknown';
+}
+
+function shouldLogTailSegment(index: number | undefined, totalSegmentCount: number | undefined) {
+  if (index === undefined || totalSegmentCount === undefined) {
+    return false;
+  }
+  return index >= Math.max(0, totalSegmentCount - 32);
+}
 
 export type EncryptConfiguration = {
   allowList?: OriginAllowList;
@@ -1037,6 +1062,9 @@ async function updateChunkQueue(
         cryptoService,
         specVersion,
         slice: chunks.slice(i, i + LEGACY_SEGMENTS_PER_DOWNLOAD),
+        sliceEndIndex: Math.min(chunks.length, i + LEGACY_SEGMENTS_PER_DOWNLOAD),
+        sliceStartIndex: i,
+        totalSegmentCount: chunks.length,
       }).catch(() => undefined)
     );
   }
@@ -1064,6 +1092,9 @@ async function fetchAndDecryptChunkSlice({
   cryptoService,
   specVersion,
   slice,
+  sliceEndIndex,
+  sliceStartIndex,
+  totalSegmentCount,
 }: {
   centralDirectory: CentralDirectory[];
   zipReader: ZipReader;
@@ -1073,24 +1104,59 @@ async function fetchAndDecryptChunkSlice({
   cryptoService: CryptoService;
   specVersion: string;
   slice: Chunk[];
+  sliceEndIndex?: number;
+  sliceStartIndex?: number;
+  totalSegmentCount?: number;
 }) {
+  const firstChunk = slice[0];
+  const lastChunk = slice[slice.length - 1];
+  const encryptedSegmentSizes = slice.map(({ encryptedSegmentSize }) => encryptedSegmentSize);
+  const plainSegmentSizes = slice.map(({ plainSegmentSize }) => plainSegmentSize);
   let buffer!: Uint8Array;
+  const bufferSize = slice.reduce(
+    (currentVal, { encryptedSegmentSize }) => currentVal + (encryptedSegmentSize as number),
+    0
+  );
+  logLargeDecryptDebug('fetch-slice:start', {
+    sliceLength: slice.length,
+    firstSegmentIndex: sliceStartIndex ?? firstChunk.index,
+    lastSegmentIndex:
+      sliceEndIndex !== undefined ? sliceEndIndex - 1 : lastChunk.index,
+    firstEncryptedOffset: firstChunk.encryptedOffset,
+    lastEncryptedOffset: lastChunk.encryptedOffset,
+    bufferSize,
+    encryptedSegmentSizes,
+    plainSegmentSizes,
+  });
   try {
-    const bufferSize = slice.reduce(
-      (currentVal, { encryptedSegmentSize }) => currentVal + (encryptedSegmentSize as number),
-      0
-    );
     buffer = await zipReader.getPayloadSegment(
       centralDirectory,
       '0.payload',
-      slice[0].encryptedOffset,
+      firstChunk.encryptedOffset,
       bufferSize
     );
+    logLargeDecryptDebug('fetch-slice:complete', {
+      sliceLength: slice.length,
+      firstSegmentIndex: sliceStartIndex ?? firstChunk.index,
+      lastSegmentIndex:
+        sliceEndIndex !== undefined ? sliceEndIndex - 1 : lastChunk.index,
+      bufferSize,
+      actualReturnedBufferLength: buffer.length,
+    });
   } catch (error) {
     const wrappedError =
       error instanceof InvalidFileError
         ? error
         : new NetworkError('unable to fetch payload segment', error);
+    logLargeDecryptDebug('fetch-slice:error', {
+      sliceLength: slice.length,
+      firstSegmentIndex: sliceStartIndex ?? firstChunk.index,
+      lastSegmentIndex:
+        sliceEndIndex !== undefined ? sliceEndIndex - 1 : lastChunk.index,
+      bufferSize,
+      errorName: wrappedError.name,
+      errorMessage: wrappedError.message,
+    });
     rejectChunks(slice, wrappedError);
     throw wrappedError;
   }
@@ -1104,9 +1170,20 @@ async function fetchAndDecryptChunkSlice({
       cipher,
       segmentIntegrityAlgorithm,
       specVersion,
+      totalSegmentCount,
     });
   } catch (error) {
     const wrappedError = asDecryptError(error, 'failed to decrypt payload segment');
+    logLargeDecryptDebug('decrypt-slice:error', {
+      sliceLength: slice.length,
+      firstSegmentIndex: sliceStartIndex ?? firstChunk.index,
+      lastSegmentIndex:
+        sliceEndIndex !== undefined ? sliceEndIndex - 1 : lastChunk.index,
+      bufferSize,
+      actualReturnedBufferLength: buffer.length,
+      errorName: wrappedError.name,
+      errorMessage: wrappedError.message,
+    });
     rejectChunks(slice, wrappedError);
     throw wrappedError;
   }
@@ -1258,6 +1335,7 @@ export async function sliceAndDecrypt({
   cryptoService,
   segmentIntegrityAlgorithm,
   specVersion,
+  totalSegmentCount,
 }: {
   buffer: Uint8Array;
   reconstructedKey: SymmetricKey;
@@ -1266,9 +1344,23 @@ export async function sliceAndDecrypt({
   cryptoService: CryptoService;
   segmentIntegrityAlgorithm: IntegrityAlgorithm;
   specVersion: string;
+  totalSegmentCount?: number;
 }) {
+  const firstChunk = slice[0];
+  const lastChunk = slice[slice.length - 1];
+  logLargeDecryptDebug('decrypt-slice:start', {
+    sliceLength: slice.length,
+    firstSegmentIndex: firstChunk.index,
+    lastSegmentIndex: lastChunk.index,
+    firstEncryptedOffset: firstChunk.encryptedOffset,
+    lastEncryptedOffset: lastChunk.encryptedOffset,
+    bufferLength: buffer.length,
+    encryptedSegmentSizes: slice.map(({ encryptedSegmentSize }) => encryptedSegmentSize),
+    plainSegmentSizes: slice.map(({ plainSegmentSize }) => plainSegmentSize),
+  });
   for (const index in slice) {
-    const { encryptedOffset, encryptedSegmentSize, plainSegmentSize } = slice[index];
+    const chunk = slice[index];
+    const { encryptedOffset, encryptedSegmentSize, plainSegmentSize } = chunk;
 
     const offset =
       slice[0].encryptedOffset === 0 ? encryptedOffset : encryptedOffset % slice[0].encryptedOffset;
@@ -1279,10 +1371,24 @@ export async function sliceAndDecrypt({
     }
 
     try {
+      if (shouldLogTailSegment(chunk.index, totalSegmentCount)) {
+        logLargeDecryptDebug('decrypt-segment:start', {
+          sliceLength: slice.length,
+          firstSegmentIndex: firstChunk.index,
+          lastSegmentIndex: lastChunk.index,
+          segmentIndex: chunk.index,
+          segmentOffsetWithinSlice: offset,
+          encryptedOffset,
+          encryptedSegmentSize,
+          plainSegmentSize,
+          bufferLength: buffer.length,
+          encryptedChunkLength: encryptedChunk.length,
+        });
+      }
       const result = await decryptChunk(
         encryptedChunk,
         reconstructedKey,
-        slice[index]['hash'],
+        chunk.hash,
         cipher,
         segmentIntegrityAlgorithm,
         specVersion,
@@ -1293,9 +1399,37 @@ export async function sliceAndDecrypt({
           `incorrect segment size: found [${result.payload.length()}], expected [${plainSegmentSize}]`
         );
       }
-      slice[index].decryptedChunk.set(result);
+      if (shouldLogTailSegment(chunk.index, totalSegmentCount)) {
+        logLargeDecryptDebug('decrypt-segment:complete', {
+          sliceLength: slice.length,
+          firstSegmentIndex: firstChunk.index,
+          lastSegmentIndex: lastChunk.index,
+          segmentIndex: chunk.index,
+          segmentOffsetWithinSlice: offset,
+          encryptedOffset,
+          encryptedSegmentSize,
+          plainSegmentSize,
+          payloadLength: result.payload.length(),
+          payloadStorageType: getBinaryStorageType(result.payload),
+        });
+      }
+      chunk.decryptedChunk.set(result);
     } catch (e) {
-      slice[index].decryptedChunk.reject(e);
+      logLargeDecryptDebug('decrypt-segment:error', {
+        sliceLength: slice.length,
+        firstSegmentIndex: firstChunk.index,
+        lastSegmentIndex: lastChunk.index,
+        segmentIndex: chunk.index,
+        segmentOffsetWithinSlice: offset,
+        encryptedOffset,
+        encryptedSegmentSize,
+        plainSegmentSize,
+        bufferLength: buffer.length,
+        encryptedChunkLength: encryptedChunk.length,
+        errorName: e instanceof Error ? e.name : typeof e,
+        errorMessage: e instanceof Error ? e.message : String(e),
+      });
+      chunk.decryptedChunk.reject(e);
     }
   }
 }
@@ -1404,9 +1538,10 @@ export async function decryptStreamFrom(
       hash,
       encryptedSegmentSize = encryptedSegmentSizeDefault,
       segmentSize = segmentSizeDefault,
-    }) => {
+    }, index) => {
       const chunk: Chunk = {
         hash,
+        index,
         encryptedOffset: mapOfRequestsOffset,
         encryptedSegmentSize,
         decryptedChunk: mailbox<DecryptResult>(),
@@ -1442,6 +1577,9 @@ export async function decryptStreamFrom(
           cryptoService: cfg.cryptoService,
           specVersion,
           slice: chunks.slice(startIndex, endIndex),
+          sliceEndIndex: endIndex,
+          sliceStartIndex: startIndex,
+          totalSegmentCount: chunks.length,
         }),
     });
     scheduler.fillWindow();
@@ -1463,6 +1601,10 @@ export async function decryptStreamFrom(
   const underlyingSource = {
     pull: async (controller: ReadableStreamDefaultController) => {
       if (nextChunkIndex >= chunks.length) {
+        logLargeDecryptDebug('stream-enqueue:complete', {
+          totalSegments: chunks.length,
+          totalEncryptedProgress: progress,
+        });
         controller.close();
         return;
       }
@@ -1470,10 +1612,50 @@ export async function decryptStreamFrom(
       const chunk = chunks[nextChunkIndex];
       const decryptedSegment = await chunk.decryptedChunk;
       const encryptedSegmentSize = chunk.encryptedSegmentSize ?? 0;
+      const payloadStorageType = getBinaryStorageType(decryptedSegment.payload);
+      let plainChunk: Uint8Array;
+      try {
+        plainChunk = new Uint8Array(decryptedSegment.payload.asArrayBuffer());
+      } catch (error) {
+        logLargeDecryptDebug('stream-enqueue:error', {
+          chunkIndex: chunk.index,
+          encryptedOffset: chunk.encryptedOffset,
+          encryptedSegmentSize,
+          plainSegmentSize: chunk.plainSegmentSize,
+          payloadLength: decryptedSegment.payload.length(),
+          payloadStorageType,
+          progress,
+          errorName: error instanceof Error ? error.name : typeof error,
+          errorMessage: error instanceof Error ? error.message : String(error),
+        });
+        throw error;
+      }
 
-      controller.enqueue(new Uint8Array(decryptedSegment.payload.asByteArray()));
+      if (
+        chunk.index === 0 ||
+        chunk.index === chunks.length - 1 ||
+        (chunk.index !== undefined && chunk.index >= chunks.length - 4)
+      ) {
+        logLargeDecryptDebug('stream-enqueue:chunk', {
+          chunkIndex: chunk.index,
+          encryptedOffset: chunk.encryptedOffset,
+          encryptedSegmentSize,
+          plainSegmentSize: chunk.plainSegmentSize,
+          payloadLength: decryptedSegment.payload.length(),
+          payloadStorageType,
+          progress,
+        });
+      }
+
+      controller.enqueue(plainChunk);
       progress += encryptedSegmentSize;
       cfg.progressHandler?.(progress);
+      // Release the resolved plaintext held by the consumed mailbox so long
+      // browser decrypts do not retain every prior segment in memory.
+      chunks[nextChunkIndex] = {
+        ...chunk,
+        decryptedChunk: mailbox<DecryptResult>(),
+      };
       nextChunkIndex += 1;
       scheduler?.markConsumed();
     },

--- a/lib/tdf3/src/utils/zip-reader.ts
+++ b/lib/tdf3/src/utils/zip-reader.ts
@@ -11,6 +11,10 @@ const LOCAL_FILE_HEADER_FIXED_SIZE = 30;
 const VERSION_NEEDED_TO_EXTRACT_ZIP64 = 45;
 const manifestMaxSize = 1024 * 1024 * 10; // 10 MB
 
+function logLargeDecryptZipDebug(event: string, details: Record<string, unknown>) {
+  console.debug(`[opentdf][decrypt-debug] ${event}`, details);
+}
+
 const cp437 =
   '\u0000☺☻♥♦♣♠•◘○◙♂♀♪♫☼►◄↕‼¶§▬↨↑↓→←∟↔▲▼ !"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~⌂ÇüéâäàåçêëèïîìÄÅÉæÆôöòûùÿÖÜ¢£¥₧ƒáíóúñÑªº¿⌐¬½¼¡«»░▒▓│┤╡╢╖╕╣║╗╝╜╛┐└┴┬├─┼╞╟╚╔╩╦╠═╬╧╨╤╥╙╘╒╓╫╪┘┌█▄▌▐▀αßΓπΣσµτΦΘΩδ∞φε∩≡±≥≤⌠⌡÷≈°∙·√ⁿ²■ ';
 
@@ -133,8 +137,40 @@ export class ZipReader {
       cdObj.relativeOffsetOfLocalHeader + cdObj.headerLength + encrpytedSegmentOffset;
     // TODO: what's the exact byte start?
     const byteEnd = byteStart + encryptedSegmentSize;
-
-    return await this.getChunk(byteStart, byteEnd);
+    const requestedRangeLength = byteEnd - byteStart;
+    logLargeDecryptZipDebug('zip-reader:get-payload-segment:start', {
+      payloadName,
+      encryptedSegmentOffset: encrpytedSegmentOffset,
+      encryptedSegmentSize,
+      byteStart,
+      byteEnd,
+      requestedRangeLength,
+    });
+    try {
+      const payload = await this.getChunk(byteStart, byteEnd);
+      logLargeDecryptZipDebug('zip-reader:get-payload-segment:complete', {
+        payloadName,
+        encryptedSegmentOffset: encrpytedSegmentOffset,
+        encryptedSegmentSize,
+        byteStart,
+        byteEnd,
+        requestedRangeLength,
+        actualReturnedBufferLength: payload.length,
+      });
+      return payload;
+    } catch (error) {
+      logLargeDecryptZipDebug('zip-reader:get-payload-segment:error', {
+        payloadName,
+        encryptedSegmentOffset: encrpytedSegmentOffset,
+        encryptedSegmentSize,
+        byteStart,
+        byteEnd,
+        requestedRangeLength,
+        errorName: error instanceof Error ? error.name : typeof error,
+        errorMessage: error instanceof Error ? error.message : String(error),
+      });
+      throw error;
+    }
   }
 
   /**

--- a/lib/tdf3/src/utils/zip-reader.ts
+++ b/lib/tdf3/src/utils/zip-reader.ts
@@ -11,10 +11,6 @@ const LOCAL_FILE_HEADER_FIXED_SIZE = 30;
 const VERSION_NEEDED_TO_EXTRACT_ZIP64 = 45;
 const manifestMaxSize = 1024 * 1024 * 10; // 10 MB
 
-function logLargeDecryptZipDebug(event: string, details: Record<string, unknown>) {
-  console.debug(`[opentdf][decrypt-debug] ${event}`, details);
-}
-
 const cp437 =
   '\u0000☺☻♥♦♣♠•◘○◙♂♀♪♫☼►◄↕‼¶§▬↨↑↓→←∟↔▲▼ !"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~⌂ÇüéâäàåçêëèïîìÄÅÉæÆôöòûùÿÖÜ¢£¥₧ƒáíóúñÑªº¿⌐¬½¼¡«»░▒▓│┤╡╢╖╕╣║╗╝╜╛┐└┴┬├─┼╞╟╚╔╩╦╠═╬╧╨╤╥╙╘╒╓╫╪┘┌█▄▌▐▀αßΓπΣσµτΦΘΩδ∞φε∩≡±≥≤⌠⌡÷≈°∙·√ⁿ²■ ';
 
@@ -137,40 +133,7 @@ export class ZipReader {
       cdObj.relativeOffsetOfLocalHeader + cdObj.headerLength + encrpytedSegmentOffset;
     // TODO: what's the exact byte start?
     const byteEnd = byteStart + encryptedSegmentSize;
-    const requestedRangeLength = byteEnd - byteStart;
-    logLargeDecryptZipDebug('zip-reader:get-payload-segment:start', {
-      payloadName,
-      encryptedSegmentOffset: encrpytedSegmentOffset,
-      encryptedSegmentSize,
-      byteStart,
-      byteEnd,
-      requestedRangeLength,
-    });
-    try {
-      const payload = await this.getChunk(byteStart, byteEnd);
-      logLargeDecryptZipDebug('zip-reader:get-payload-segment:complete', {
-        payloadName,
-        encryptedSegmentOffset: encrpytedSegmentOffset,
-        encryptedSegmentSize,
-        byteStart,
-        byteEnd,
-        requestedRangeLength,
-        actualReturnedBufferLength: payload.length,
-      });
-      return payload;
-    } catch (error) {
-      logLargeDecryptZipDebug('zip-reader:get-payload-segment:error', {
-        payloadName,
-        encryptedSegmentOffset: encrpytedSegmentOffset,
-        encryptedSegmentSize,
-        byteStart,
-        byteEnd,
-        requestedRangeLength,
-        errorName: error instanceof Error ? error.name : typeof error,
-        errorMessage: error instanceof Error ? error.message : String(error),
-      });
-      throw error;
-    }
+    return this.getChunk(byteStart, byteEnd);
   }
 
   /**

--- a/lib/tests/mocha/unit/crypto/crypto-service.spec.ts
+++ b/lib/tests/mocha/unit/crypto/crypto-service.spec.ts
@@ -1,6 +1,7 @@
 import { assert, expect } from 'chai';
 
 import { Algorithms } from '../../../../tdf3/src/ciphers/index.js';
+import { AesGcmCipher } from '../../../../tdf3/src/ciphers/aes-gcm-cipher.js';
 import {
   decrypt,
   decryptWithPrivateKey,
@@ -24,6 +25,7 @@ import {
   verifyHmac,
   verify,
 } from '../../../../tdf3/src/crypto/index.js';
+import * as DefaultCryptoService from '../../../../tdf3/src/crypto/index.js';
 import { hex } from '../../../../src/encodings/index.js';
 import { Binary } from '../../../../tdf3/src/binary.js';
 import { decodeArrayBuffer, encodeArrayBuffer } from '../../../../src/encodings/base64.js';
@@ -241,6 +243,23 @@ describe('Crypto Service', () => {
     expect(encrypted).to.have.property('authTag');
     const decrypted = await decrypt(encrypted.payload, key, iv, algo, encrypted.authTag);
     expect(decrypted.payload.asString()).to.be.equal(rawData);
+  });
+
+  it('should decrypt aes_256_gcm ciphertext from Uint8Array input', async () => {
+    const rawData = 'hello world';
+    const payload = Binary.fromString(rawData);
+
+    const keyBytes = new Uint8Array(
+      decodeArrayBuffer('cvR6X2vLG5ap13ssLxRjOV1KOjJfraYpD8D+97zdtY4=')
+    );
+    const key = await importSymmetricKey(keyBytes);
+    const iv = Binary.fromArrayBuffer(crypto.getRandomValues(new Uint8Array(12)).buffer);
+    const cipher = new AesGcmCipher(DefaultCryptoService);
+
+    const encrypted = await cipher.encrypt(payload, key, iv);
+    const decrypted = await cipher.decrypt(new Uint8Array(encrypted.payload.asArrayBuffer()), key);
+
+    expect(decrypted.payload.asString()).to.equal(rawData);
   });
 
   describe('generateECKeyPair', () => {

--- a/lib/tests/mocha/unit/crypto/crypto-service.spec.ts
+++ b/lib/tests/mocha/unit/crypto/crypto-service.spec.ts
@@ -262,6 +262,23 @@ describe('Crypto Service', () => {
     expect(decrypted.payload.asString()).to.equal(rawData);
   });
 
+  it('should decrypt aes_256_gcm ciphertext from ArrayBuffer input', async () => {
+    const rawData = 'hello world';
+    const payload = Binary.fromString(rawData);
+
+    const keyBytes = new Uint8Array(
+      decodeArrayBuffer('cvR6X2vLG5ap13ssLxRjOV1KOjJfraYpD8D+97zdtY4=')
+    );
+    const key = await importSymmetricKey(keyBytes);
+    const iv = Binary.fromArrayBuffer(crypto.getRandomValues(new Uint8Array(12)).buffer);
+    const cipher = new AesGcmCipher(DefaultCryptoService);
+
+    const encrypted = await cipher.encrypt(payload, key, iv);
+    const decrypted = await cipher.decrypt(encrypted.payload.asArrayBuffer(), key);
+
+    expect(decrypted.payload.asString()).to.equal(rawData);
+  });
+
   describe('generateECKeyPair', () => {
     it('should generate P-256 key pair', async () => {
       const keyPair = await generateECKeyPair('P-256');

--- a/web-app/tests/tests/acts.ts
+++ b/web-app/tests/tests/acts.ts
@@ -1,5 +1,7 @@
+export const appUrl = 'http://localhost:65432/';
+
 export const authorize = async (page: Page) => {
-  await page.goto('http://localhost:65432/');
+  await page.goto(appUrl);
   // If we are logged in, return early.
   const sessionState = await page.locator('#sessionState').textContent();
   if (sessionState === 'loggedin') {

--- a/web-app/tests/tests/huge.spec.ts
+++ b/web-app/tests/tests/huge.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect, type Page } from '@playwright/test';
 import fs from 'node:fs';
-import { authorize, loadFile } from './acts.js';
+import { appUrl, authorize, loadFile } from './acts.js';
 
 test.beforeEach(async ({ page }) => {
   page.on('pageerror', (err) => {
@@ -42,7 +42,7 @@ test('Large File', async ({ page }) => {
 
     await page.locator('#randomSelector').clear();
     await loadFile(page, cipherTextPath);
-    const plainDownloadPromise = await page.waitForEvent('download', { timeout: 60000 });
+    const plainDownloadPromise = page.waitForEvent('download', { timeout: 60000 });
     await page.locator('#fileSink').click();
     await page.locator('#decryptButton').click();
     const download2 = await plainDownloadPromise;


### PR DESCRIPTION
## Summary

Fix large browser decrypts from chunker sources failing near EOF due to memory pressure in @opentdf/sdk.

Main bug upstream: consumed decrypted segments stayed referenced in the decrypt queue after enqueue, so long- running browser decrypts retained plaintext history and eventually killed the tab. This change releases consumed plaintext promptly and also removes a few avoidable decrypt-path copies that were amplifying heap pressure.

Validated with a browser-local harness using local @opentdf/sdk:

- encrypt 8 GiB file: succeeds
- decrypt 8 GiB file: previously failed around ~7.979 GiB
- decrypt 8 GiB file after fix: completes successfully

## Root Cause

Browser decrypt path for chunker sources was not truly bounded in resident memory.

Most important issue:

- resolved decryptedChunk promises remained stored in chunks[] after downstream consumption
- each consumed plaintext segment therefore stayed strongly referenced
- memory usage grew across the entire download until the browser tab failed

Additional pressure came from extra buffer copies in the AES-GCM/browser decrypt path.

## What Changed

### Core fix

- release consumed plaintext after controller.enqueue(...) by replacing the consumed chunk slot with a fresh mailbox while preserving metadata

### Memory / copy reductions

- avoid payload.asByteArray() on enqueue path
- reduce redundant Uint8Array / BufferSource copying in browser crypto
- avoid unnecessary AES-GCM payload/tag churn in browser-native decrypt path

## Validation

Reproduced in standalone browser harness outside downstream app/authz/transport path.

Observed before:

- browser-local 8 GiB decrypt failed near end
- errors included RangeError: Array buffer allocation failed

Observed after:

- decrypt completes to EOF
- harness reports:
  - [done] decrypt-local complete plaintext=8.000 GiB

## Risk / Notes

- Main functional behavior should be unchanged aside from memory retention/copy behavior during decrypt.
- Debug logging is still present in this branch; may want follow-up cleanup or downgrade before merge.
- Downstream app changes are not required for correctness if upstream fix lands, though callers may still choose explicit segmentBatchSize / maxConcurrentSegmentBatches tuning for browser perf policy.

## How To Test

1. Build local lib
2. Install/relink local @opentdf/sdk into browser harness or downstream app
3. Decrypt a large local encrypted file from a chunker source
4. Confirm decrypt reaches EOF without tab crash / allocation failure


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved large file handling with enhanced memory management for better stability during encryption and decryption operations
  * Extended decryption compatibility to accept multiple buffer input formats

* **Tests**
  * Added comprehensive unit tests for AES-256-GCM cryptographic operations with various input types

* **Chores**
  * Optimized test infrastructure and updated browser configuration for large file testing support
<!-- end of auto-generated comment: release notes by coderabbit.ai -->