### PR TITLE
feat(sdk): re-export policy enums from barrel for convenient imports

### DIFF
--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -19,6 +19,12 @@ export {
   type ExternalJwtTokenProviderOptions,
 } from './auth/token-providers.js';
 export { attributeFQNsAsValues } from './policy/api.js';
+export {
+  AttributeRuleTypeEnum,
+  ConditionBooleanTypeEnum,
+  SubjectMappingOperatorEnum,
+} from './platform/policy/objects_pb.js';
+export { ActiveStateEnum } from './platform/common/common_pb.js';
 export * as EntityIdentifiers from './platform/authorization/entity-identifiers.js';
 export * as Resources from './platform/authorization/resources.js';
 /** @deprecated Use `EntityIdentifiers.forEmail()` instead. Will be removed in a future release. */

--- a/lib/tests/mocha/unit/policy-enums.spec.ts
+++ b/lib/tests/mocha/unit/policy-enums.spec.ts
@@ -1,0 +1,32 @@
+import { expect } from 'chai';
+import {
+  ActiveStateEnum,
+  AttributeRuleTypeEnum,
+  ConditionBooleanTypeEnum,
+  SubjectMappingOperatorEnum,
+} from '../../../src/index.js';
+
+describe('Policy enum re-exports', () => {
+  it('exports SubjectMappingOperatorEnum with expected values', () => {
+    expect(SubjectMappingOperatorEnum.IN).to.equal(1);
+    expect(SubjectMappingOperatorEnum.NOT_IN).to.equal(2);
+    expect(SubjectMappingOperatorEnum.IN_CONTAINS).to.equal(3);
+  });
+
+  it('exports ConditionBooleanTypeEnum with expected values', () => {
+    expect(ConditionBooleanTypeEnum.AND).to.equal(1);
+    expect(ConditionBooleanTypeEnum.OR).to.equal(2);
+  });
+
+  it('exports AttributeRuleTypeEnum with expected values', () => {
+    expect(AttributeRuleTypeEnum.ALL_OF).to.equal(1);
+    expect(AttributeRuleTypeEnum.ANY_OF).to.equal(2);
+    expect(AttributeRuleTypeEnum.HIERARCHY).to.equal(3);
+  });
+
+  it('exports ActiveStateEnum with expected values', () => {
+    expect(ActiveStateEnum.ACTIVE).to.equal(1);
+    expect(ActiveStateEnum.INACTIVE).to.equal(2);
+    expect(ActiveStateEnum.ANY).to.equal(3);
+  });
+});


### PR DESCRIPTION
## Summary

- Re-export `SubjectMappingOperatorEnum`, `ConditionBooleanTypeEnum`, `AttributeRuleTypeEnum`, and `ActiveStateEnum` from the main `@opentdf/sdk` entry point
- Users no longer need to reach into generated proto paths for commonly used policy enums
- Companion to opentdf/platform#3408 (Go SDK) and opentdf/java-sdk#357 (Java SDK)

### Before / After

```typescript
// Before — deep import into generated proto internals
import { SubjectMappingOperatorEnum } from '@opentdf/sdk/platform/policy/objects_pb.js';
import { ActiveStateEnum } from '@opentdf/sdk/platform/common/common_pb.js';

// After — clean top-level import
import { SubjectMappingOperatorEnum, ActiveStateEnum } from '@opentdf/sdk';
```

Usage is the same either way — the TS enum names are already short:

```typescript
condition.operator = SubjectMappingOperatorEnum.IN;
group.booleanOperator = ConditionBooleanTypeEnum.AND;
attribute.rule = AttributeRuleTypeEnum.HIERARCHY;
request.state = ActiveStateEnum.ACTIVE;
```

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm run build` succeeds
- [x] `npx mocha 'dist/web/tests/mocha/unit/policy-enums.spec.js'` — 4 tests, all pass
- [x] `npm run format` — no changes needed
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Four new enums added to the public API: `AttributeRuleTypeEnum`, `ConditionBooleanTypeEnum`, `SubjectMappingOperatorEnum`, and `ActiveStateEnum` for policy and state management configuration.

* **Tests**
  * Added unit tests validating the correctness of newly exposed enums.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->