### PR TITLE
fix(ci): fix update-protos workflow failing on large generated files

### DIFF
--- a/.github/workflows/update-protos.yaml
+++ b/.github/workflows/update-protos.yaml
@@ -135,7 +135,7 @@ jobs:
         working-directory: ./web-sdk
         if: steps.update-platform-protos.outputs.changes == 'true'
         run: |
-          git add -A
+          git add lib/src/platform/ lib/platform-proto-version.json
           git commit -m "fix(sdk): update proto bindings to $LATEST_TAG"
           git push origin $BRANCH_NAME
         env:

--- a/.github/workflows/update-protos.yaml
+++ b/.github/workflows/update-protos.yaml
@@ -143,7 +143,7 @@ jobs:
             echo "Committing file: $file"
 
             # Write base64 to a temp file to avoid "Argument list too long" on large generated files
-            base64 -i $file > /tmp/b64content
+            base64 -w 0 $file > /tmp/b64content
             FILENAME=$(basename $file)
             MESSAGE="Update $FILENAME to match platform tag $LATEST_TAG"
 

--- a/.github/workflows/update-protos.yaml
+++ b/.github/workflows/update-protos.yaml
@@ -128,36 +128,16 @@ jobs:
         if: steps.check-pr.outputs.EXISTING_PR == '' && steps.update-platform-protos.outputs.changes == 'true'
         run: |
           git checkout -b $BRANCH_NAME
-          git push origin $BRANCH_NAME
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH_NAME: update-platform-protos
 
-      - name: Update files
+      - name: Commit and push changes
         working-directory: ./web-sdk
         if: steps.update-platform-protos.outputs.changes == 'true'
         run: |
-          echo "Committing changes..."
-          FILES_CHANGED=$(git status --porcelain | awk '{print $2}')
-          for file in $FILES_CHANGED; do
-            echo "Committing file: $file"
-
-            # Write base64 to a temp file to avoid "Argument list too long" on large generated files
-            base64 -w 0 $file > /tmp/b64content
-            FILENAME=$(basename $file)
-            MESSAGE="Update $FILENAME to match platform tag $LATEST_TAG"
-
-            SHA=$( git rev-parse $BRANCH_NAME:$file 2>/dev/null | grep -E '^[0-9a-f]{40}$' || echo "" )
-            if [ -z "$SHA" ]; then
-              SHA=""
-            fi
-
-            gh api --method PUT /repos/opentdf/web-sdk/contents/$file \
-              --field message="$MESSAGE" \
-              --raw-field content=@/tmp/b64content \
-              --field branch="$BRANCH_NAME" \
-              --field sha="$SHA"
-          done
+          git add lib/src/platform/ lib/platform-proto-version.json
+          git commit -m "fix(sdk): update proto bindings to $LATEST_TAG"
+          git push origin $BRANCH_NAME
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH_NAME: update-platform-protos

--- a/.github/workflows/update-protos.yaml
+++ b/.github/workflows/update-protos.yaml
@@ -128,16 +128,36 @@ jobs:
         if: steps.check-pr.outputs.EXISTING_PR == '' && steps.update-platform-protos.outputs.changes == 'true'
         run: |
           git checkout -b $BRANCH_NAME
+          git push origin $BRANCH_NAME
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH_NAME: update-platform-protos
 
-      - name: Commit and push changes
+      - name: Update files
         working-directory: ./web-sdk
         if: steps.update-platform-protos.outputs.changes == 'true'
         run: |
-          git add -A
-          git commit -m "fix(sdk): update proto bindings to $LATEST_TAG"
-          git push origin $BRANCH_NAME
+          echo "Committing changes..."
+          FILES_CHANGED=$(git status --porcelain | awk '{print $2}')
+          for file in $FILES_CHANGED; do
+            echo "Committing file: $file"
+
+            # Write base64 to a temp file to avoid "Argument list too long" on large generated files
+            base64 -i $file > /tmp/b64content
+            FILENAME=$(basename $file)
+            MESSAGE="Update $FILENAME to match platform tag $LATEST_TAG"
+
+            SHA=$( git rev-parse $BRANCH_NAME:$file 2>/dev/null | grep -E '^[0-9a-f]{40}$' || echo "" )
+            if [ -z "$SHA" ]; then
+              SHA=""
+            fi
+
+            gh api --method PUT /repos/opentdf/web-sdk/contents/$file \
+              --field message="$MESSAGE" \
+              --raw-field content=@/tmp/b64content \
+              --field branch="$BRANCH_NAME" \
+              --field sha="$SHA"
+          done
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH_NAME: update-platform-protos

--- a/.github/workflows/update-protos.yaml
+++ b/.github/workflows/update-protos.yaml
@@ -135,7 +135,7 @@ jobs:
         working-directory: ./web-sdk
         if: steps.update-platform-protos.outputs.changes == 'true'
         run: |
-          git add lib/src/platform/ lib/platform-proto-version.json
+          git add -A
           git commit -m "fix(sdk): update proto bindings to $LATEST_TAG"
           git push origin $BRANCH_NAME
         env:

--- a/.github/workflows/update-protos.yaml
+++ b/.github/workflows/update-protos.yaml
@@ -128,36 +128,16 @@ jobs:
         if: steps.check-pr.outputs.EXISTING_PR == '' && steps.update-platform-protos.outputs.changes == 'true'
         run: |
           git checkout -b $BRANCH_NAME
-          git push origin $BRANCH_NAME
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH_NAME: update-platform-protos
 
-      - name: Update files
+      - name: Commit and push changes
         working-directory: ./web-sdk
         if: steps.update-platform-protos.outputs.changes == 'true'
         run: |
-          echo "Committing changes..."
-          FILES_CHANGED=$(git status --porcelain | awk '{print $2}')
-          for file in $FILES_CHANGED; do
-            echo "Committing file: $file"
-
-            CONTENT=$(base64 -i $file)
-            FILENAME=$(basename $file)
-            MESSAGE="Update $FILENAME to match platform tag $LATEST_TAG"
-
-            SHA=$( git rev-parse $BRANCH_NAME:$file 2>/dev/null | grep -E '^[0-9a-f]{40}$' || echo "" )
-            if [ -z "$SHA" ]; then
-              SHA=""
-            fi
-
-            gh api --method PUT /repos/opentdf/web-sdk/contents/$file \
-              --field message="$MESSAGE" \
-              --field content="$CONTENT" \
-              --field encoding="base64" \
-              --field branch="$BRANCH_NAME" \
-              --field sha="$SHA"
-          done
+          git add -A
+          git commit -m "fix(sdk): update proto bindings to $LATEST_TAG"
+          git push origin $BRANCH_NAME
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH_NAME: update-platform-protos


### PR DESCRIPTION
## Summary
- The `update-protos.yaml` workflow has been failing for 5+ days because it uploads each generated file via `gh api --method PUT` (GitHub Contents API), which passes base64-encoded content as a CLI argument. Large files like `validate_pb.ts` exceed the shell's argument length limit ("Argument list too long").
- Replaced the file-by-file Contents API upload with `git add -A && git commit && git push`, which has no file size constraints.
- This unblocks the proto bump to `protocol/go/v0.33.1` which includes the new search/sort/filter types needed for DSPX-312.


## The error 

https://github.com/opentdf/web-sdk/actions/runs/27709887043/job/81967942871

```
Committing changes...
Committing file: lib/src/platform/buf/validate/validate_pb.ts
/home/runner/work/_temp/cef46946-22e8-48d9-8206-870d899f246a.sh: line 15: /usr/bin/gh: Argument list too long
```

## Test Run
https://github.com/opentdf/web-sdk/actions/runs/27710777426

## Summary by CodeRabbit

* **Chores**
  * Updated internal workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->