### PR TITLE
fix(ci): switch npm publish to OIDC trusted publishing

### DIFF
--- a/.github/workflows/deliver.yaml
+++ b/.github/workflows/deliver.yaml
@@ -16,7 +16,6 @@ jobs:
   deliver:
     permissions:
       contents: write
+      id-token: write
       packages: write
     uses: opentdf/web-sdk/.github/workflows/reusable_deliver.yaml@main
-    secrets:
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/reusable_deliver.yaml
+++ b/.github/workflows/reusable_deliver.yaml
@@ -1,10 +1,7 @@
 name: "Reusable worflow: Deliver Client to npm registry"
 
 on:
-  workflow_call:
-    secrets:
-      NPM_TOKEN:
-        required: true
+  workflow_call: {}
 
 # Default empty permissions for all jobs
 permissions: {}
@@ -80,6 +77,7 @@ jobs:
   deliver-npmjs:
     permissions:
       contents: read
+      id-token: write
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout repo"
@@ -110,7 +108,7 @@ jobs:
         env:
           DIST_TAG: ${{ steps.guess-build-metadata.outputs.DIST_TAG }}
           FULL_VERSION: ${{ steps.guess-build-metadata.outputs.FULL_VERSION }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: "true"
         run: |
           bash scripts/deliver-to-npm-registry.sh "$FULL_VERSION" "$DIST_TAG"
 


### PR DESCRIPTION
## Summary
- Replace static `NPM_TOKEN` secret with GitHub Actions OIDC for npmjs publishing
- The token expired, causing E404 on `npm publish` (npm returns 404 instead of 401/403 for invalid tokens)
- Trusted publisher is already configured on npmjs.org for both `@opentdf/sdk` and `@opentdf/ctl`

### Changes
- **`deliver.yaml`** — Add `id-token: write` permission, remove `secrets: NPM_TOKEN` passthrough
- **`reusable_deliver.yaml`** — Remove `secrets` requirement from `workflow_call`, add `id-token: write` to `deliver-npmjs` job, replace `NODE_AUTH_TOKEN` with `NPM_CONFIG_PROVENANCE: "true"`

## Test plan
- [ ] Merge and re-run the release workflow
- [ ] Verify `@opentdf/sdk@0.18.0` and `@opentdf/ctl@0.18.0` publish successfully to npmjs
- [ ] Verify `deliver-ghp` job is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced security for package publishing through improved identity verification mechanisms
  * Enabled package provenance tracking for increased transparency in the software supply chain

<!-- end of auto-generated comment: release notes by coderabbit.ai -->