### PR TITLE
fix(tdf3): remove TODO from customer-facing error message

### DIFF
--- a/lib/tdf3/src/tdf.ts
+++ b/lib/tdf3/src/tdf.ts
@@ -731,7 +731,7 @@ export function splitLookupTableFactory(
       // A proper fix would handle this by deduplicating or selecting the appropriate key.
       throw new InvalidFileError(
         `Unable to decrypt: Multiple keys detected for Key Access Server [${kao.url}]. ` +
-        `Please contact your administrator.`
+          `Please contact your administrator.`
       );
     }
     if (allowed(kao)) {

--- a/lib/tdf3/src/tdf.ts
+++ b/lib/tdf3/src/tdf.ts
@@ -726,8 +726,12 @@ export function splitLookupTableFactory(
   for (const kao of keyAccess) {
     const disjunction = splitPotentials[kao.sid ?? ''];
     if (kao.url in disjunction) {
+      // TODO(DSPX-3454): Implement fallback to no split ids when repetition is detected.
+      // Repetition occurs when multiple KAS keys share the same URL within a split.
+      // A proper fix would handle this by deduplicating or selecting the appropriate key.
       throw new InvalidFileError(
-        `TODO: Fallback to no split ids. Repetition found for [${kao.url}] on split [${kao.sid}]`
+        `Unable to decrypt: Multiple keys detected for Key Access Server [${kao.url}]. ` +
+        `Please contact your administrator.`
       );
     }
     if (allowed(kao)) {

--- a/lib/tdf3/src/tdf.ts
+++ b/lib/tdf3/src/tdf.ts
@@ -726,9 +726,10 @@ export function splitLookupTableFactory(
   for (const kao of keyAccess) {
     const disjunction = splitPotentials[kao.sid ?? ''];
     if (kao.url in disjunction) {
-      // TODO(DSPX-3454): Implement fallback to no split ids when repetition is detected.
-      // Repetition occurs when multiple KAS keys share the same URL within a split.
-      // A proper fix would handle this by deduplicating or selecting the appropriate key.
+      // TODO(DSPX-3454): Handle duplicate KAS URLs with different KIDs.
+      // Each KAO contains a KID - the function should be updated to use this
+      // information to differentiate between keys from the same KAS.
+      // Cross-SDK validation needed via xtest.
       throw new InvalidFileError(
         `Unable to decrypt: Multiple keys detected for Key Access Server [${kao.url}]. ` +
           `Please contact your administrator.`

--- a/lib/tests/mocha/unit/tdf.spec.ts
+++ b/lib/tests/mocha/unit/tdf.spec.ts
@@ -302,7 +302,7 @@ describe('splitLookupTableFactory', () => {
 
     expect(() => TDF.splitLookupTableFactory(keyAccess, allowedKases)).to.throw(
       InvalidFileError,
-      'TODO: Fallback to no split ids. Repetition found for [https://kas1] on split [split1]'
+      'Unable to decrypt: Multiple keys detected for Key Access Server [https://kas1]. Please contact your administrator.'
     );
   });
 


### PR DESCRIPTION
## Summary
Fixes DSPX-3454 - removes TODO from customer-facing error message in Secure Viewer.

A customer reported seeing: `"TODO: Fallback to no split ids. Repetition found for..."` in error output when decryption failed.

## Changes
- Replaced customer-facing error with user-friendly message: `"Unable to decrypt: Multiple keys detected for Key Access Server [URL]. Please contact your administrator."`
- Kept developer TODO as code comment for future implementation of split ID fallback logic

## Impact
- Customers no longer see internal TODO messages in error output
- Developer context preserved in code comments for future work

## Related
- Follow-up ticket created: DSPX-3666 (audit codebase-wide for other customer-facing TODOs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation error messaging for split key-to-URL configuration issues. If multiple keys map to the same URL within a split, the error now clearly reports “Multiple keys detected” and includes guidance to contact your administrator.  
* **Tests**
  * Updated the unit test expectations to match the revised error message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->