### PR TITLE
fix(sdk): Drops user_info check, does local `exp` check

### DIFF
--- a/lib/src/access/access-fetch.ts
+++ b/lib/src/access/access-fetch.ts
@@ -68,7 +68,9 @@ export async function fetchWrappedKey(
       case 401:
         throw new UnauthenticatedError(`401 for [${req.url}]; rewrap auth failure`);
       case 403:
-        throw new PermissionDeniedError(`403 for [${req.url}]; rewrap permission denied: forbidden`);
+        throw new PermissionDeniedError(
+          `403 for [${req.url}]; rewrap permission denied: forbidden`
+        );
       default:
         if (response.status >= 500) {
           throw new ServiceError(

--- a/lib/src/access/access-fetch.ts
+++ b/lib/src/access/access-fetch.ts
@@ -68,7 +68,7 @@ export async function fetchWrappedKey(
       case 401:
         throw new UnauthenticatedError(`401 for [${req.url}]; rewrap auth failure`);
       case 403:
-        throw new PermissionDeniedError(`403 for [${req.url}]; rewrap permission denied`);
+        throw new PermissionDeniedError(`403 forbidden for [${req.url}]; rewrap permission denied`);
       default:
         if (response.status >= 500) {
           throw new ServiceError(

--- a/lib/src/access/access-fetch.ts
+++ b/lib/src/access/access-fetch.ts
@@ -68,7 +68,7 @@ export async function fetchWrappedKey(
       case 401:
         throw new UnauthenticatedError(`401 for [${req.url}]; rewrap auth failure`);
       case 403:
-        throw new PermissionDeniedError(`403 forbidden for [${req.url}]; rewrap permission denied`);
+        throw new PermissionDeniedError(`403 for [${req.url}]; rewrap permission denied: forbidden`);
       default:
         if (response.status >= 500) {
           throw new ServiceError(

--- a/lib/src/access/access-rpc.ts
+++ b/lib/src/access/access-rpc.ts
@@ -101,7 +101,9 @@ export function handleRpcRewrapErrorString(
         requiredObligations
       );
     }
-    throw new PermissionDeniedError(`403 for [${platformUrl}]; rewrap permission denied: forbidden`);
+    throw new PermissionDeniedError(
+      `403 for [${platformUrl}]; rewrap permission denied: forbidden`
+    );
   }
   if (e.includes(Code[Code.Unauthenticated])) {
     // 401 Unauthorized

--- a/lib/src/access/access-rpc.ts
+++ b/lib/src/access/access-rpc.ts
@@ -65,7 +65,7 @@ export function handleRpcRewrapError(e: unknown, platformUrl: string): never {
         throw new InvalidFileError(`400 for [${platformUrl}]: rewrap bad request [${e.message}]`);
       case Code.PermissionDenied: // 403 Forbidden
         throw new PermissionDeniedError(
-          `403 forbidden for [${platformUrl}]; rewrap permission denied`
+          `403 for [${platformUrl}]; rewrap permission denied: forbidden`
         );
       case Code.Unauthenticated: // 401 Unauthorized
         throw new UnauthenticatedError(`401 for [${platformUrl}]; rewrap auth failure`);
@@ -97,11 +97,11 @@ export function handleRpcRewrapErrorString(
   if (e.includes(Code[Code.PermissionDenied])) {
     if (requiredObligations && requiredObligations.length > 0) {
       throw new PermissionDeniedError(
-        `403 forbidden for [${platformUrl}]; rewrap permission denied`,
+        `403 for [${platformUrl}]; rewrap permission denied: forbidden`,
         requiredObligations
       );
     }
-    throw new PermissionDeniedError(`403 forbidden for [${platformUrl}]; rewrap permission denied`);
+    throw new PermissionDeniedError(`403 for [${platformUrl}]; rewrap permission denied: forbidden`);
   }
   if (e.includes(Code[Code.Unauthenticated])) {
     // 401 Unauthorized

--- a/lib/src/access/access-rpc.ts
+++ b/lib/src/access/access-rpc.ts
@@ -64,7 +64,9 @@ export function handleRpcRewrapError(e: unknown, platformUrl: string): never {
       case Code.InvalidArgument: // 400 Bad Request
         throw new InvalidFileError(`400 for [${platformUrl}]: rewrap bad request [${e.message}]`);
       case Code.PermissionDenied: // 403 Forbidden
-        throw new PermissionDeniedError(`403 for [${platformUrl}]; rewrap permission denied`);
+        throw new PermissionDeniedError(
+          `403 forbidden for [${platformUrl}]; rewrap permission denied`
+        );
       case Code.Unauthenticated: // 401 Unauthorized
         throw new UnauthenticatedError(`401 for [${platformUrl}]; rewrap auth failure`);
       case Code.Internal:
@@ -95,11 +97,11 @@ export function handleRpcRewrapErrorString(
   if (e.includes(Code[Code.PermissionDenied])) {
     if (requiredObligations && requiredObligations.length > 0) {
       throw new PermissionDeniedError(
-        `403 for [${platformUrl}]; rewrap permission denied`,
+        `403 forbidden for [${platformUrl}]; rewrap permission denied`,
         requiredObligations
       );
     }
-    throw new PermissionDeniedError(`403 for [${platformUrl}]; rewrap permission denied`);
+    throw new PermissionDeniedError(`403 forbidden for [${platformUrl}]; rewrap permission denied`);
   }
   if (e.includes(Code[Code.Unauthenticated])) {
     // 401 Unauthorized

--- a/lib/src/auth/oidc.ts
+++ b/lib/src/auth/oidc.ts
@@ -1,5 +1,6 @@
 import { default as dpopFn } from './dpop.js';
 import { HttpRequest, withHeaders } from './auth.js';
+import { isTokenExpired, resolveTokenExpiry } from './tokenExpiry.js';
 import { base64 } from '../encodings/index.js';
 import { ConfigurationError, TdfError } from '../errors.js';
 import { rstrip } from '../utils.js';
@@ -60,6 +61,7 @@ const qstringify = (obj: Record<string, string>) => new URLSearchParams(obj).toS
 export type AccessTokenResponse = {
   access_token: string;
   refresh_token?: string;
+  expires_in?: number;
 };
 
 /**
@@ -99,7 +101,8 @@ export class AccessToken {
 
   extraHeaders: Record<string, string> = {};
 
-  currentAccessToken?: string;
+  /** Absolute expiry (seconds since epoch) of the cached access token in `data`. */
+  cachedExpiry?: number;
 
   cryptoService: CryptoService;
 
@@ -227,32 +230,32 @@ export class AccessToken {
 
   /**
    * Gets an access token; operates lazily/cached, with an optional check for freshness.
-   * @param validate if we should run a inline check against the OIDC 'userinfo' endpoint to make sure any cached access token is still valid
+   *
+   * Freshness is determined locally from the token's `exp` claim (or the OAuth
+   * `expires_in` from the token response) — no network round trip. This replaces an
+   * earlier scheme that validated cached tokens against the OIDC `userinfo` endpoint.
+   * @param validate if we should check that any cached access token is still fresh
+   *   before returning it; when false, a cached token is returned regardless of expiry
    * @returns
    */
   async get(validate = true): Promise<string> {
-    if (this.data?.access_token) {
-      try {
-        if (validate) {
-          await this.info(this.data.access_token);
-        }
-        return this.data.access_token;
-      } catch (e) {
-        console.log('access_token fails on user_info endpoint; attempting to renew', e);
-        if (this.data?.refresh_token) {
-          // Prefer the latest refresh_token if present over creds passed in
-          // to constructor
-          this.config = {
-            ...this.config,
-            exchange: 'refresh',
-            refreshToken: this.data.refresh_token,
-          };
-        }
-        delete this.data;
-      }
+    if (this.data?.access_token && (!validate || !isTokenExpired(this.cachedExpiry))) {
+      return this.data.access_token;
     }
 
+    if (this.data?.refresh_token) {
+      // Prefer the latest refresh_token if present over creds passed in
+      // to constructor
+      this.config = {
+        ...this.config,
+        exchange: 'refresh',
+        refreshToken: this.data.refresh_token,
+      };
+    }
+    delete this.data;
+
     const tokenResponse = (this.data = await this.accessTokenLookup(this.config));
+    this.cachedExpiry = resolveTokenExpiry(tokenResponse.access_token, tokenResponse.expires_in);
     return tokenResponse.access_token;
   }
 
@@ -264,13 +267,14 @@ export class AccessToken {
    * Calling this function will trigger a forcible token refresh using the cached refresh token, and contact the auth server.
    */
   async refreshTokenClaimsWithClientPubkeyIfNeeded(signingKey: KeyPair): Promise<void> {
-    // If we already have a token, and the pubkey changes,
-    // we need to force a refresh now - otherwise
-    // we can wait until we create the token for the first time
-    if (this.currentAccessToken && signingKey === this.signingKey) {
+    // If we already have a token, and the pubkey is unchanged,
+    // we can keep the cached token - otherwise drop it so the next `get()`
+    // refetches a token bound to the new public key.
+    if (this.data?.access_token && signingKey === this.signingKey) {
       return;
     }
-    delete this.currentAccessToken;
+    delete this.data;
+    delete this.cachedExpiry;
     this.signingKey = signingKey;
   }
 
@@ -307,7 +311,7 @@ export class AccessToken {
         'Client public key was not set via `updateClientPublicKey` or passed in via constructor; required when DPoP is enabled'
       );
     }
-    const accessToken = (this.currentAccessToken ??= await this.get());
+    const accessToken = await this.get();
     if (this.config.dpopEnabled && this.signingKey) {
       const dpopToken = await dpopFn(
         this.signingKey,

--- a/lib/src/auth/oidc.ts
+++ b/lib/src/auth/oidc.ts
@@ -104,6 +104,9 @@ export class AccessToken {
   /** Absolute expiry (seconds since epoch) of the cached access token in `data`. */
   cachedExpiry?: number;
 
+  /** In-flight token exchange, used to dedupe concurrent `get()` calls. */
+  inFlight?: Promise<string>;
+
   cryptoService: CryptoService;
 
   constructor(cfg: OIDCCredentials, cryptoService: CryptoService, request?: typeof fetch) {
@@ -243,20 +246,36 @@ export class AccessToken {
       return this.data.access_token;
     }
 
-    if (this.data?.refresh_token) {
-      // Prefer the latest refresh_token if present over creds passed in
-      // to constructor
-      this.config = {
-        ...this.config,
-        exchange: 'refresh',
-        refreshToken: this.data.refresh_token,
-      };
+    // Dedupe concurrent refreshes so a burst of requests triggers one exchange.
+    if (this.inFlight) {
+      return this.inFlight;
     }
-    delete this.data;
 
-    const tokenResponse = (this.data = await this.accessTokenLookup(this.config));
-    this.cachedExpiry = resolveTokenExpiry(tokenResponse.access_token, tokenResponse.expires_in);
-    return tokenResponse.access_token;
+    this.inFlight = (async () => {
+      try {
+        if (this.data?.refresh_token) {
+          // Prefer the latest refresh_token if present over creds passed in
+          // to constructor
+          this.config = {
+            ...this.config,
+            exchange: 'refresh',
+            refreshToken: this.data.refresh_token,
+          };
+        }
+        delete this.data;
+
+        const tokenResponse = (this.data = await this.accessTokenLookup(this.config));
+        this.cachedExpiry = resolveTokenExpiry(
+          tokenResponse.access_token,
+          tokenResponse.expires_in
+        );
+        return tokenResponse.access_token;
+      } finally {
+        delete this.inFlight;
+      }
+    })();
+
+    return this.inFlight;
   }
 
   /**
@@ -275,6 +294,7 @@ export class AccessToken {
     }
     delete this.data;
     delete this.cachedExpiry;
+    delete this.inFlight;
     this.signingKey = signingKey;
   }
 

--- a/lib/src/auth/token-providers.ts
+++ b/lib/src/auth/token-providers.ts
@@ -1,4 +1,5 @@
 import { type TokenProvider } from './interceptors.js';
+import { isTokenExpired, resolveTokenExpiry } from './tokenExpiry.js';
 import { ConfigurationError, TdfError } from '../errors.js';
 import { rstrip } from '../utils.js';
 
@@ -60,40 +61,6 @@ function resolveTokenEndpoint(oidcOrigin: string, override?: string): string {
     throw new ConfigurationError('oidcOrigin or oidcTokenEndpoint is required');
   }
   return `${rstrip(base, '/')}/protocol/openid-connect/token`;
-}
-
-/**
- * Decode a JWT's exp claim without verifying the signature.
- * Returns the expiration time in seconds since epoch, or undefined if not present.
- */
-function getJwtExpiration(token: string): number | undefined {
-  try {
-    const parts = token.split('.');
-    if (parts.length !== 3) return undefined;
-    // Base64url decode the payload
-    const payload = parts[1].replace(/-/g, '+').replace(/_/g, '/');
-    const padded = payload + '='.repeat((4 - (payload.length % 4)) % 4);
-    const decoded = JSON.parse(atob(padded));
-    return typeof decoded.exp === 'number' ? decoded.exp : undefined;
-  } catch {
-    return undefined;
-  }
-}
-
-/**
- * Compute the absolute expiry (seconds since epoch) for a token response.
- * Prefers `expires_in` from the token response, falls back to the JWT `exp` claim.
- */
-function resolveTokenExpiry(accessToken: string, expiresIn?: number): number | undefined {
-  if (typeof expiresIn === 'number') {
-    return Date.now() / 1000 + expiresIn;
-  }
-  return getJwtExpiration(accessToken);
-}
-
-function isTokenExpired(expiry: number | undefined, bufferSeconds = 30): boolean {
-  if (expiry === undefined) return true;
-  return Date.now() / 1000 >= expiry - bufferSeconds;
 }
 
 async function fetchToken(

--- a/lib/src/auth/tokenExpiry.ts
+++ b/lib/src/auth/tokenExpiry.ts
@@ -27,12 +27,12 @@ export function getJwtExpiration(token: string): number | undefined {
  */
 export function resolveTokenExpiry(accessToken: string, expiresIn?: number): number | undefined {
   if (typeof expiresIn === 'number') {
-    return Date.now() / 1000 + expiresIn;
+    return Math.floor(Date.now() / 1000) + expiresIn;
   }
   return getJwtExpiration(accessToken);
 }
 
 export function isTokenExpired(expiry: number | undefined, bufferSeconds = 30): boolean {
   if (expiry === undefined) return true;
-  return Date.now() / 1000 >= expiry - bufferSeconds;
+  return Math.floor(Date.now() / 1000) >= expiry - bufferSeconds;
 }

--- a/lib/src/auth/tokenExpiry.ts
+++ b/lib/src/auth/tokenExpiry.ts
@@ -1,0 +1,38 @@
+/**
+ * Helpers for deciding whether a cached access token is still fresh, using the
+ * JWT `exp` claim (or an OAuth `expires_in`) rather than a network round trip.
+ */
+
+/**
+ * Decode a JWT's exp claim without verifying the signature.
+ * Returns the expiration time in seconds since epoch, or undefined if not present.
+ */
+export function getJwtExpiration(token: string): number | undefined {
+  try {
+    const parts = token.split('.');
+    if (parts.length !== 3) return undefined;
+    // Base64url decode the payload
+    const payload = parts[1].replace(/-/g, '+').replace(/_/g, '/');
+    const padded = payload + '='.repeat((4 - (payload.length % 4)) % 4);
+    const decoded = JSON.parse(atob(padded));
+    return typeof decoded.exp === 'number' ? decoded.exp : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Compute the absolute expiry (seconds since epoch) for a token response.
+ * Prefers `expires_in` from the token response, falls back to the JWT `exp` claim.
+ */
+export function resolveTokenExpiry(accessToken: string, expiresIn?: number): number | undefined {
+  if (typeof expiresIn === 'number') {
+    return Date.now() / 1000 + expiresIn;
+  }
+  return getJwtExpiration(accessToken);
+}
+
+export function isTokenExpired(expiry: number | undefined, bufferSeconds = 30): boolean {
+  if (expiry === undefined) return true;
+  return Date.now() / 1000 >= expiry - bufferSeconds;
+}

--- a/lib/tests/web/access/access-fetch.test.ts
+++ b/lib/tests/web/access/access-fetch.test.ts
@@ -125,7 +125,7 @@ describe('access-fetch.js', () => {
         expect.fail('Should have thrown');
       } catch (e) {
         expect(e).to.be.instanceOf(PermissionDeniedError);
-        expect(e.message).to.equal(`403 forbidden for [${url}]; rewrap permission denied`);
+        expect(e.message).to.equal(`403 for [${url}]; rewrap permission denied: forbidden`);
       }
     });
 

--- a/lib/tests/web/access/access-fetch.test.ts
+++ b/lib/tests/web/access/access-fetch.test.ts
@@ -125,7 +125,7 @@ describe('access-fetch.js', () => {
         expect.fail('Should have thrown');
       } catch (e) {
         expect(e).to.be.instanceOf(PermissionDeniedError);
-        expect(e.message).to.equal(`403 for [${url}]; rewrap permission denied`);
+        expect(e.message).to.equal(`403 forbidden for [${url}]; rewrap permission denied`);
       }
     });
 

--- a/lib/tests/web/auth/auth.test.ts
+++ b/lib/tests/web/auth/auth.test.ts
@@ -346,6 +346,38 @@ describe('AccessToken', () => {
       expect(res).to.eql('a');
       expect(mf.callCount).to.eql(1);
     });
+    it('should dedupe concurrent refreshes into a single token exchange', async () => {
+      const signingKey = await generateTestSigningKey();
+      const json = fake.resolves({ access_token: 'a' });
+      const mf = fake((url: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+        if (!init) {
+          return Promise.reject('No init found');
+        }
+        if (init.method === 'POST') {
+          return Promise.resolve({ ...ok, json });
+        }
+        return Promise.reject(`yee [${url}] [${JSON.stringify(init.headers)}]`);
+      });
+      const accessTokenClient = new AccessToken(
+        {
+          oidcOrigin: 'https://auth.invalid',
+          clientId: 'myid',
+          clientSecret: 'mysecret',
+          exchange: 'client',
+          signingKey,
+        },
+        DefaultCryptoService,
+        mf
+      );
+      // Fire several gets before any resolves; only one exchange should happen.
+      const results = await Promise.all([
+        accessTokenClient.get(),
+        accessTokenClient.get(),
+        accessTokenClient.get(),
+      ]);
+      expect(results).to.eql(['a', 'a', 'a']);
+      expect(mf.callCount).to.eql(1);
+    });
   });
 
   describe('withCreds', () => {

--- a/lib/tests/web/auth/auth.test.ts
+++ b/lib/tests/web/auth/auth.test.ts
@@ -35,6 +35,13 @@ async function generateTestSigningKey(): Promise<KeyPair> {
   return generateSigningKeyPair();
 }
 
+// Build a minimal unsigned JWT carrying just an `exp` claim (seconds since epoch).
+function makeJwt(exp: number): string {
+  const b64u = (o: object) =>
+    btoa(JSON.stringify(o)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+  return `${b64u({ alg: 'none' })}.${b64u({ exp })}.sig`;
+}
+
 // Due to Jest mocks not working with ESModules currently,
 // these tests use poor man's mocking
 describe('AccessToken', () => {
@@ -281,7 +288,7 @@ describe('AccessToken', () => {
   });
 
   describe('cached tokenset', () => {
-    it('should call userinfo endpoint and return cached tokenset', async () => {
+    it('should return a fresh cached token without any network call', async () => {
       const signingKey = await generateTestSigningKey();
       const mf = mockFetch({ access_token: 'notreal' });
       const accessTokenClient = new AccessToken(
@@ -295,17 +302,18 @@ describe('AccessToken', () => {
         DefaultCryptoService,
         mf
       );
+      const fresh = makeJwt(Date.now() / 1000 + 300);
       accessTokenClient.data = {
         refresh_token: 'r',
-        access_token: 'a',
+        access_token: fresh,
       };
-      // Do a refresh to cache tokenset
+      accessTokenClient.cachedExpiry = Date.now() / 1000 + 300;
+      // Freshness is now decided locally; no userinfo round trip.
       const res = await accessTokenClient.get();
-      expect(res).to.eql('a');
-      // TODO Why do we do an info call here?
-      // expect(mf.callCount).to.eql(0);
+      expect(res).to.eql(fresh);
+      expect(mf.callCount).to.eql(0);
     });
-    it('should attempt to refresh token if userinfo call throws error', async () => {
+    it('should refresh the token when the cached token is expired', async () => {
       const signingKey = await generateTestSigningKey();
       const json = fake.resolves({ access_token: 'a' });
       const mf = fake((url: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
@@ -330,12 +338,13 @@ describe('AccessToken', () => {
       );
       accessTokenClient.data = {
         refresh_token: 'r',
-        access_token: 'a',
+        access_token: 'old',
       };
-      // Do a refresh to cache tokenset
+      accessTokenClient.cachedExpiry = Date.now() / 1000 - 10; // already expired
+      // Only the token endpoint (POST) is hit - the userinfo GET is gone.
       const res = await accessTokenClient.get();
       expect(res).to.eql('a');
-      expect(mf.callCount).to.eql(2);
+      expect(mf.callCount).to.eql(1);
     });
   });
 


### PR DESCRIPTION
## Why

Running tests (and the `ctl` CLI flow) produced noisy auth failures:

```
access_token fails on user_info endpoint; attempting to renew
TdfError: auth info fail: GET [.../openid-connect/userinfo] => 403 Forbidden
```

`AccessToken.get()` "validated" a cached token by calling the OIDC **userinfo**
endpoint (`info()`). This is:

- **Usually gives warnings**: Most access tokens don't need user info, so you shouldn't configure your OIDC application with permission, so most of the time this would return an error anyway
- **Unnecessary**: interceptors only need a valid bearer/DPoP token string; none
  consult userinfo. The modern `token-providers.ts` already replaced this exact job
  with a local JWT `exp` freshness check. (There was even a standing
  `// TODO Why do we do an info call here?` in the auth tests.)
- **Buggy with DPoP**:`info()` signs the DPoP proof with `htm: 'POST'` but issues a
  **GET**, so Keycloak rejects the `htm` mismatch → the 403 + spurious renewals above.

## What

- New `lib/src/auth/tokenExpiry.ts` — extracted shared `getJwtExpiration` /
  `resolveTokenExpiry` / `isTokenExpired` helpers.
- `token-providers.ts` — import the helpers instead of defining them locally (no
  behavior change).
- `oidc.ts` — `get()` now decides freshness locally via `isTokenExpired(cachedExpiry)`
  instead of hitting userinfo; added `expires_in` to `AccessTokenResponse` and a
  `cachedExpiry` field; `withCreds()` calls `get()` per request (cheap when fresh) so
  expiry-based refresh actually takes effect; `refreshTokenClaimsWithClientPubkeyIfNeeded()`
  re-pointed at the new cache. `info()`/`userInfoEndpoint` are kept (still public +
  directly tested) but no longer called internally.
- `auth.test.ts` — rewrote the two `cached tokenset` tests for local-expiry behavior
  (fresh token → zero network calls; expired token → exactly one POST refresh, no
  userinfo GET).

Previously:
<img width="1215" height="388" alt="image" src="https://github.com/user-attachments/assets/e380cbc6-d371-4ad8-9c3a-294e1c371147" />

Now:
<img width="1215" height="544" alt="image" src="https://github.com/user-attachments/assets/2f2f333c-7d7e-4792-98a7-3662b6f3cf39" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved token freshness handling so valid cached sign-in tokens can be reused without extra network checks.
  * Added smarter handling for concurrent authentication requests, reducing duplicate refresh/exchange calls.

* **Bug Fixes**
  * Updated permission-denied messages to be clearer and more consistent when access is blocked.
  * Fixed cached token refresh behavior so expired tokens are refreshed reliably, while still keeping fresh tokens available offline-friendly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->