### PR TITLE
fix(ci): remove hardcoded default tag from update-protos workflow

### DIFF
--- a/.github/workflows/update-protos.yaml
+++ b/.github/workflows/update-protos.yaml
@@ -12,9 +12,8 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "The new tag for targeting the RPC protocol buffers."
-        required: true
-        default: "protocol/go/v0.13.0"
+        description: "The new tag for targeting the RPC protocol buffers. Leave empty to auto-detect latest."
+        required: false
 
 jobs:
   update-platform-protos:


### PR DESCRIPTION
## Summary
- The `workflow_dispatch` input for `tag` had `required: true` with a hardcoded `default: "protocol/go/v0.13.0"`
- Manual triggers without specifying a tag would use this stale default instead of auto-detecting the latest protocol tag
- This caused PR #962 to generate stubs from v0.13.0 instead of v0.37.0, which would have removed namespace fields
- Fix: make `tag` optional with no default, so manual dispatch falls through to the `sort -V` auto-detection path (same as scheduled runs)

## Test plan
- [ ] Merge this PR
- [ ] Manually trigger the "Update protos" workflow without specifying a tag
- [ ] Verify the generated PR targets the latest `protocol/go/` tag (currently v0.37.0)

Ref: DSPX-3838

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The protocol update workflow now allows the tag field to be left empty, automatically using the latest available protocol version.
  * Improved flexibility when triggering the workflow by removing the need to provide a fixed default tag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->