### PR TITLE
fix(ci): allow Go toolchain auto-download in platform-roundtrip

### DIFF
--- a/.github/workflows/reusable_build-and-test.yaml
+++ b/.github/workflows/reusable_build-and-test.yaml
@@ -208,6 +208,12 @@ jobs:
             .github/workflows/roundtrip/platform/protocol/go/go.sum
             .github/workflows/roundtrip/platform/sdk/go.sum
             .github/workflows/roundtrip/platform/service/go.sum
+      - name: Allow Go toolchain auto-download
+        # setup-go pins GOTOOLCHAIN=local; the platform's go.work may require a
+        # newer Go toolchain than the version installed from service/go.mod.
+        # Let Go fetch the required toolchain automatically so platform
+        # provisioning (e.g. keycloak) doesn't fail on a version mismatch.
+        run: echo "GOTOOLCHAIN=auto" >> "$GITHUB_ENV"
       - run: find ./ -name go.mod
       - name: verify platform go.work
         run: |-


### PR DESCRIPTION
## Summary

The `build-and-test / platform-roundtrip` job is failing for all PRs whose roundtrip job runs, with:

```
go: platform/go.work requires go >= 1.25.5 (running go 1.25.0; GOTOOLCHAIN=local)
[ERROR] unable to provision keycloak
[ERROR] Couldn't run platform
Process completed with exit code 2.
```

### Root cause
The job clones `opentdf/platform` and installs Go via `setup-go` using `go-version-file: .../platform/service/go.mod` (resolves to **1.25.0**). `actions/setup-go` pins `GOTOOLCHAIN=local` (exported via `$GITHUB_ENV`) when installing an exact version. The platform's `go.work` now requires **≥ 1.25.5**, so `go run ./platform/service provision keycloak` refuses to fetch the newer toolchain and provisioning fails before the SDK is even exercised.

### Fix
Add a step immediately after `setup-go` that sets `GOTOOLCHAIN=auto` via `$GITHUB_ENV`, letting Go download whatever toolchain `go.work` requires. It's placed **after** `setup-go` so its `$GITHUB_ENV` write takes precedence over setup-go's `GOTOOLCHAIN=local` (last write wins) for all subsequent steps.

```yaml
- name: Allow Go toolchain auto-download
  run: echo "GOTOOLCHAIN=auto" >> "$GITHUB_ENV"
```

### ⚠️ Note on verifying this PR
The caller `build-and-test.yaml` pins the reusable workflow to `@main`:

```yaml
uses: opentdf/web-sdk/.github/workflows/reusable_build-and-test.yaml@main
```

Because of this pin, **every PR (including this one) runs `main`'s copy of the reusable workflow, not the branch's edited copy.** So this PR's own `platform-roundtrip` check will remain **red** — it runs main's old workflow, where the fix does not yet exist. This is expected, not a sign the fix is broken. The fix only takes effect once merged to `main`; after merge, re-running the roundtrip on any open PR (e.g. #965) will confirm it is green.

### Notes
- Single-line CI change; no source or dependency changes.
- Unblocks #965 (and any other PR) once merged.
- Alternative considered: point `go-version-file` at `platform/go.work` (installs the required version directly). Auto-download was chosen per request as it self-heals across future platform toolchain bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)