### PR TITLE
fix(sdk): allow the same KAS to wrap the same split (DSPX-3379)

### DIFF
--- a/lib/tdf3/src/tdf.ts
+++ b/lib/tdf3/src/tdf.ts
@@ -720,11 +720,9 @@ export function splitLookupTableFactory(
       ...disallowedKases
     );
   }
-  // Each split id maps to the list of KAOs that can unwrap it (a disjunction:
-  // any one succeeding unwraps the split). The same KAS may legitimately appear
-  // more than once for a split - an authoring mistake (same key used twice) or
-  // intentional multiple keys on one KAS - so we keep every allowed KAO as an
-  // alternative rather than rejecting duplicates. See DSPX-3379.
+  // Each split id maps to the list of KAOs that can unwrap it (in a disjunction,
+  // any one succeeding unwraps the split). Note: a KAS may appear several times
+  // for the same split, possibly using different keys to encrypt the same split value.
   const splitPotentials: Record<string, KeyAccessObject[]> = Object.fromEntries(
     [...splitIds].map((s) => [s, []])
   );
@@ -935,7 +933,7 @@ async function unwrapKey({
     potentials.forEach((keySplitInfo, i) => {
       // Key by url+kid+index so multiple KAOs on the same KAS stay distinct
       // alternatives within the split's disjunction (anyPool tries each until
-      // one succeeds). See DSPX-3379.
+      // one succeeds).
       const alternativeKey = `${keySplitInfo.url}#${keySplitInfo.kid ?? ''}#${i}`;
       anyPromises[alternativeKey] = async () => {
         try {

--- a/lib/tdf3/src/tdf.ts
+++ b/lib/tdf3/src/tdf.ts
@@ -706,11 +706,11 @@ export async function loadTDFStream(chunker: Chunker): Promise<InspectedTDFOverv
 export function splitLookupTableFactory(
   keyAccess: KeyAccessObject[],
   allowedKases: OriginAllowList
-): Record<string, Record<string, KeyAccessObject>> {
+): Record<string, KeyAccessObject[]> {
   const allowed = (k: KeyAccessObject) => allowedKases.allows(k.url);
   const splitIds = new Set(keyAccess.map(({ sid }) => sid ?? ''));
 
-  const accessibleSplits = new Set(keyAccess.filter(allowed).map(({ sid }) => sid));
+  const accessibleSplits = new Set(keyAccess.filter(allowed).map(({ sid }) => sid ?? ''));
   if (splitIds.size > accessibleSplits.size) {
     const disallowedKases = new Set(keyAccess.filter((k) => !allowed(k)).map(({ url }) => url));
     throw new UnsafeUrlError(
@@ -720,23 +720,17 @@ export function splitLookupTableFactory(
       ...disallowedKases
     );
   }
-  const splitPotentials: Record<string, Record<string, KeyAccessObject>> = Object.fromEntries(
-    [...splitIds].map((s) => [s, {}])
+  // Each split id maps to the list of KAOs that can unwrap it (a disjunction:
+  // any one succeeding unwraps the split). The same KAS may legitimately appear
+  // more than once for a split - an authoring mistake (same key used twice) or
+  // intentional multiple keys on one KAS - so we keep every allowed KAO as an
+  // alternative rather than rejecting duplicates. See DSPX-3379.
+  const splitPotentials: Record<string, KeyAccessObject[]> = Object.fromEntries(
+    [...splitIds].map((s) => [s, []])
   );
   for (const kao of keyAccess) {
-    const disjunction = splitPotentials[kao.sid ?? ''];
-    if (kao.url in disjunction) {
-      // TODO(DSPX-3454): Handle duplicate KAS URLs with different KIDs.
-      // Each KAO contains a KID - the function should be updated to use this
-      // information to differentiate between keys from the same KAS.
-      // Cross-SDK validation needed via xtest.
-      throw new InvalidFileError(
-        `Unable to decrypt: Multiple keys detected for Key Access Server [${kao.url}]. ` +
-          `Please contact your administrator.`
-      );
-    }
     if (allowed(kao)) {
-      disjunction[kao.url] = kao;
+      splitPotentials[kao.sid ?? ''].push(kao);
     }
   }
   return splitPotentials;
@@ -931,22 +925,26 @@ async function unwrapKey({
   const splitPromises: Record<string, () => Promise<RewrapResponseData>> = {};
   for (const splitId of Object.keys(splitPotentials)) {
     const potentials = splitPotentials[splitId];
-    if (!potentials || !Object.keys(potentials).length) {
+    if (!potentials?.length) {
       throw new UnsafeUrlError(
         `Unreconstructable key - no valid KAS found for split ${JSON.stringify(splitId)}`,
         ''
       );
     }
     const anyPromises: Record<string, () => Promise<RewrapResponseData>> = {};
-    for (const [kas, keySplitInfo] of Object.entries(potentials)) {
-      anyPromises[kas] = async () => {
+    potentials.forEach((keySplitInfo, i) => {
+      // Key by url+kid+index so multiple KAOs on the same KAS stay distinct
+      // alternatives within the split's disjunction (anyPool tries each until
+      // one succeeds). See DSPX-3379.
+      const alternativeKey = `${keySplitInfo.url}#${keySplitInfo.kid ?? ''}#${i}`;
+      anyPromises[alternativeKey] = async () => {
         try {
           return await tryKasRewrap(keySplitInfo);
         } catch (e) {
           throw handleRewrapError(e as Error);
         }
       };
-    }
+    });
     splitPromises[splitId] = () => anyPool(poolSize, anyPromises);
   }
   try {

--- a/lib/tests/mocha/encrypt-decrypt.spec.ts
+++ b/lib/tests/mocha/encrypt-decrypt.spec.ts
@@ -363,6 +363,58 @@ describe('encrypt decrypt test', async function () {
     }
   }
 
+  it('decrypts when the same KAS wraps the same split twice (DSPX-3379)', async function () {
+    const cipher = new AesGcmCipher(WebCryptoService);
+    const encryptionInformation = new SplitKey(cipher);
+    const key1 = await encryptionInformation.generateKey();
+    const keyMiddleware = async () => ({ keyForEncryption: key1, keyForManifest: key1 });
+
+    const client = new Client.Client({
+      kasEndpoint: kasUrl,
+      platformUrl: kasUrl,
+      allowedKases: [kasUrl],
+      dpopKeys: Mocks.entityKeyPair(),
+      clientId: 'id',
+      authProvider,
+    });
+
+    const scope: Scope = { dissem: ['user@domain.com'], attributes: [] };
+
+    // Two KAOs pointing at the same KAS for the same split id: the same KAS
+    // wraps the same split twice. Previously this threw; now the copies are
+    // disjunction alternatives and the file must still decrypt.
+    const encryptedStream = await client.encrypt({
+      metadata: Mocks.getMetadataObject(),
+      wrappingKeyAlgorithm: 'rsa:2048',
+      offline: true,
+      scope,
+      keyMiddleware,
+      splitPlan: [
+        { kas: kasUrl, sid: '1' },
+        { kas: kasUrl, sid: '1' },
+      ],
+      source: new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode(expectedVal));
+          controller.close();
+        },
+      }),
+    });
+
+    const kaos = encryptedStream.manifest.encryptionInformation.keyAccess;
+    assert.equal(kaos.length, 2, 'expected two KAOs for the duplicated split');
+    assert.equal(kaos[0].url, kaos[1].url);
+    assert.equal(kaos[0].sid, kaos[1].sid);
+
+    const decryptStream = await client.decrypt({
+      source: { type: 'stream', location: encryptedStream.stream },
+      wrappingKeyAlgorithm: 'rsa:2048',
+    });
+
+    const { value: decryptedText } = await decryptStream.stream.getReader().read();
+    assert.equal(new TextDecoder().decode(decryptedText), expectedVal);
+  });
+
   it('encrypt-decrypt with system metadata assertion', async function () {
     const cipher = new AesGcmCipher(WebCryptoService);
     const encryptionInformation = new SplitKey(cipher);

--- a/lib/tests/mocha/unit/tdf.spec.ts
+++ b/lib/tests/mocha/unit/tdf.spec.ts
@@ -260,8 +260,8 @@ describe('splitLookupTableFactory', () => {
     const result = TDF.splitLookupTableFactory(keyAccess, allowedKases);
 
     expect(result).to.deep.equal({
-      split1: { 'https://kas1': keyAccess[0] },
-      split2: { 'https://kas2': keyAccess[1] },
+      split1: [keyAccess[0]],
+      split2: [keyAccess[1]],
     });
   });
 
@@ -275,8 +275,8 @@ describe('splitLookupTableFactory', () => {
     const result = TDF.splitLookupTableFactory(keyAccess, allowedKases);
 
     expect(result).to.deep.equal({
-      split1: { 'https://kas1': keyAccess[0] },
-      split2: { 'https://kas2': keyAccess[1] },
+      split1: [keyAccess[0]],
+      split2: [keyAccess[1]],
     });
   });
 
@@ -293,17 +293,33 @@ describe('splitLookupTableFactory', () => {
     );
   });
 
-  it('should throw for duplicate URLs in the same splitId', () => {
+  it('should keep duplicate URLs in the same splitId as alternatives (DSPX-3379)', () => {
     const keyAccess: KeyAccessObject[] = [
       { sid: 'split1', type: 'remote', url: 'https://kas1', protocol: 'kas' },
-      { sid: 'split1', type: 'remote', url: 'https://kas1', protocol: 'kas' }, // duplicate URL in same splitId
+      { sid: 'split1', type: 'remote', url: 'https://kas1', protocol: 'kas' }, // same KAS + split
     ];
     const allowedKases = new OriginAllowList(['https://kas1']);
 
-    expect(() => TDF.splitLookupTableFactory(keyAccess, allowedKases)).to.throw(
-      InvalidFileError,
-      'Unable to decrypt: Multiple keys detected for Key Access Server [https://kas1]. Please contact your administrator.'
-    );
+    const result = TDF.splitLookupTableFactory(keyAccess, allowedKases);
+
+    // Both copies are retained as disjunction alternatives; unwrap tries each.
+    expect(result).to.deep.equal({
+      split1: [keyAccess[0], keyAccess[1]],
+    });
+  });
+
+  it('should keep same-KAS different-kid entries in the same splitId (DSPX-3379)', () => {
+    const keyAccess: KeyAccessObject[] = [
+      { sid: 'split1', type: 'remote', url: 'https://kas1', protocol: 'kas', kid: 'k1' },
+      { sid: 'split1', type: 'remote', url: 'https://kas1', protocol: 'kas', kid: 'k2' },
+    ];
+    const allowedKases = new OriginAllowList(['https://kas1']);
+
+    const result = TDF.splitLookupTableFactory(keyAccess, allowedKases);
+
+    expect(result).to.deep.equal({
+      split1: [keyAccess[0], keyAccess[1]],
+    });
   });
 
   it('should handle empty keyAccess array', () => {
@@ -336,7 +352,7 @@ describe('splitLookupTableFactory', () => {
     const result = TDF.splitLookupTableFactory(keyAccess, new OriginAllowList(allowedKases));
 
     expect(result).to.deep.equal({
-      '': { 'https://kas1': keyAccess[0] },
+      '': [keyAccess[0]],
     });
   });
 });


### PR DESCRIPTION
## What

When a TDF's key-access-object (KAO) array has two entries with the **same split
id and the same KAS URI**, the web-sdk refused to decrypt, throwing
`Unable to decrypt: Multiple keys detected for Key Access Server [...]`.

This treats the KAOs for a split as a **disjunction of alternatives** (any one
succeeding unwraps the split) instead of a URL-keyed map that can hold at most
one KAO per KAS — matching how the split is already consumed downstream
(`anyPool`) and how go-sdk / java-sdk already behave.

### Changes (`lib/tdf3/src/tdf.ts`)
- `splitLookupTableFactory` now returns `Record<splitId, KeyAccessObject[]>` and
  no longer throws on a repeated `(splitId, kasUrl)`; every allowed KAO is kept
  as an alternative. Disallowed-KAS accounting (`UnsafeUrlError`) is unchanged.
- `unwrapKey` feeds each alternative to `anyPool` with a unique `url#kid#index`
  key so duplicate KAS entries are each tried until one succeeds.

## Why (DSPX-3379)

The same KAS wrapping the same split is legitimate — an authoring mistake (same
key used twice) or intentional multiple keys on one KAS. go/java read these
files fine; the web-sdk (e.g. secure viewer) failed. Expected: decrypt (or
permission-denied) exactly as if the copies lived on distinct URIs.

## Tests
- Unit: `splitLookupTableFactory` keeps duplicate `(sid, kas)` and
  same-KAS-different-KID entries as alternatives.
- In-process decrypt path: a `splitPlan` with a repeated `kas`+`sid` produces a
  duplicate-KAO TDF that decrypts via the full `unwrap`/`anyPool` path.
- Full mocha suite passes (334 passing).
- Cross-SDK: `test_tdf_with_duplicate_kao_same_kas` (opentdf/tests#555) — CI is
  green for go, java, and this branch's js.

Spec: `spec/DSPX-3379.md`.

Depends on / validated by: opentdf/tests#555

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Encryption and decryption now support multiple key access alternatives from the same KAS for a single split.
  * Duplicate key access entries are preserved instead of being rejected.
  * Rewrapping correctly handles multiple alternatives, including entries with different key IDs.

* **Tests**
  * Added coverage confirming streams decrypt successfully when the same KAS wraps a split more than once.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->