### PR TITLE
chore(sdk): consolidate key-algorithm types + typed accessors (DSPX-4040)

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -16,6 +16,7 @@ import {
   OpenTDF,
   DecoratedStream,
   isPublicKeyAlgorithm,
+  PUBLIC_KEY_ALGORITHMS,
 } from '@opentdf/sdk';
 import { CLIError, Level, log } from './logger.js';
 import * as assertions from '@opentdf/sdk/assertions';
@@ -462,6 +463,7 @@ export const handleArgs = (args: string[]) => {
           group: 'Encrypt Options:',
           desc: 'Key type for wrapping keys',
           type: 'string',
+          choices: PUBLIC_KEY_ALGORITHMS,
           default: 'rsa:2048',
         },
         mimeType: {
@@ -475,6 +477,7 @@ export const handleArgs = (args: string[]) => {
           group: 'Decrypt Options:',
           desc: 'Key type for rewrap',
           type: 'string',
+          choices: PUBLIC_KEY_ALGORITHMS,
           default: 'rsa:2048',
         },
         userId: {

--- a/lib/src/access.ts
+++ b/lib/src/access.ts
@@ -2,6 +2,11 @@ import { type AuthConfig, resolveAuthConfig } from './auth/interceptors.js';
 import { RewrapResponse } from './platform/kas/kas_pb.js';
 import { getPlatformUrlFromKasEndpoint, validateSecureUrl } from './utils.js';
 import { base64 } from './encodings/index.js';
+import {
+  KEY_ALGORITHMS,
+  type KeyAlgorithm,
+  isKeyAlgorithm,
+} from '../tdf3/src/crypto/declarations.js';
 
 import {
   fetchKasBasePubKey,
@@ -87,16 +92,14 @@ export const rewrapAdditionalContextHeader = (
   return base64.encode(JSON.stringify(context));
 };
 
-export type KasPublicKeyAlgorithm =
-  | 'ec:secp256r1'
-  | 'ec:secp384r1'
-  | 'ec:secp521r1'
-  | 'rsa:2048'
-  | 'rsa:4096';
+// The supported key algorithms are defined in one place, `crypto/declarations.ts`.
+// These public aliases preserve the historic `access.ts` API surface (name, tuple
+// order, and guard behavior) while delegating to that single source of truth.
+export const PUBLIC_KEY_ALGORITHMS = KEY_ALGORITHMS;
 
-export const isPublicKeyAlgorithm = (a: string): a is KasPublicKeyAlgorithm => {
-  return a === 'ec:secp256r1' || a === 'rsa:2048';
-};
+export type KasPublicKeyAlgorithm = KeyAlgorithm;
+
+export const isPublicKeyAlgorithm = (a: string): a is KasPublicKeyAlgorithm => isKeyAlgorithm(a);
 
 export const keyAlgorithmToPublicKeyAlgorithm = (k: CryptoKey): KasPublicKeyAlgorithm => {
   const a = k.algorithm;

--- a/lib/src/access.ts
+++ b/lib/src/access.ts
@@ -92,9 +92,6 @@ export const rewrapAdditionalContextHeader = (
   return base64.encode(JSON.stringify(context));
 };
 
-// The supported key algorithms are defined in one place, `crypto/declarations.ts`.
-// These public aliases preserve the historic `access.ts` API surface (name, tuple
-// order, and guard behavior) while delegating to that single source of truth.
 export const PUBLIC_KEY_ALGORITHMS = KEY_ALGORITHMS;
 
 export type KasPublicKeyAlgorithm = KeyAlgorithm;

--- a/lib/src/auth/dpop.ts
+++ b/lib/src/auth/dpop.ts
@@ -6,7 +6,9 @@ import type {
   KeyPair,
   PrivateKey,
   AsymmetricSigningAlgorithm,
+  KeyAlgorithm,
 } from '../../tdf3/src/crypto/declarations.js';
+import { isRsaKeyAlgorithm } from '../../tdf3/src/crypto/declarations.js';
 
 export type JsonObject = { [Key in string]?: JsonValue };
 export type JsonArray = JsonValue[];
@@ -119,8 +121,8 @@ class UnsupportedOperationError extends Error {
 /**
  * Determines a supported JWS `alg` identifier from PublicKeyInfo algorithm string.
  */
-function determineJWSAlgorithmFromKeyInfo(algorithm: string): JWSAlgorithm {
-  if (algorithm.startsWith('rsa:')) {
+function determineJWSAlgorithmFromKeyInfo(algorithm: KeyAlgorithm): JWSAlgorithm {
+  if (isRsaKeyAlgorithm(algorithm)) {
     return 'RS256';
   }
   switch (algorithm) {

--- a/lib/src/opentdf.ts
+++ b/lib/src/opentdf.ts
@@ -14,6 +14,7 @@ import {
 import {
   type KasPublicKeyAlgorithm,
   OriginAllowList,
+  PUBLIC_KEY_ALGORITHMS,
   fetchKeyAccessServers,
   isPublicKeyAlgorithm,
 } from './access.js';
@@ -45,6 +46,7 @@ export {
   type Payload,
   type Segment,
   type SplitType,
+  PUBLIC_KEY_ALGORITHMS,
   isPublicKeyAlgorithm,
 };
 

--- a/lib/tdf3/src/client/index.ts
+++ b/lib/tdf3/src/client/index.ts
@@ -43,7 +43,12 @@ import {
 } from '../../../src/access.js';
 import { ConfigurationError } from '../../../src/errors.js';
 import { AesGcmCipher } from '../ciphers/aes-gcm-cipher.js';
-import { type KeyPair, type SymmetricKey } from '../crypto/declarations.js';
+import {
+  isEcKeyAlgorithm,
+  isRsaKeyAlgorithm,
+  type KeyPair,
+  type SymmetricKey,
+} from '../crypto/declarations.js';
 import * as defaultCryptoService from '../crypto/index.js';
 import {
   type AttributeObject,
@@ -730,18 +735,12 @@ export class Client {
           );
         }
         let type: KeyAccessType;
-        switch (algorithm) {
-          case 'rsa:2048':
-          case 'rsa:4096':
-            type = 'wrapped';
-            break;
-          case 'ec:secp384r1':
-          case 'ec:secp521r1':
-          case 'ec:secp256r1':
-            type = 'ec-wrapped';
-            break;
-          default:
-            throw new ConfigurationError(`Unsupported algorithm ${algorithm}`);
+        if (isRsaKeyAlgorithm(algorithm)) {
+          type = 'wrapped';
+        } else if (isEcKeyAlgorithm(algorithm)) {
+          type = 'ec-wrapped';
+        } else {
+          throw new ConfigurationError(`Unsupported algorithm ${algorithm}`);
         }
         return buildKeyAccess({
           alg: algorithm,

--- a/lib/tdf3/src/crypto/core/key-format.ts
+++ b/lib/tdf3/src/crypto/core/key-format.ts
@@ -1,4 +1,7 @@
 import {
+  ecAlgorithmToCurve,
+  isEcKeyAlgorithm,
+  isRsaKeyAlgorithm,
   type KeyAlgorithm,
   type KeyOptions,
   MIN_ASYMMETRIC_KEY_SIZE_BITS,
@@ -238,7 +241,7 @@ export async function importPublicKey(pem: string, options: KeyOptions): Promise
   let cryptoAlgorithm: RsaHashedImportParams | EcKeyImportParams;
   let keyUsages: KeyUsage[];
 
-  if (algorithm.startsWith('rsa:')) {
+  if (isRsaKeyAlgorithm(algorithm)) {
     if (usage === 'encrypt') {
       cryptoAlgorithm = rsaOaepSha1();
       keyUsages = ['encrypt'];
@@ -248,18 +251,8 @@ export async function importPublicKey(pem: string, options: KeyOptions): Promise
     } else {
       throw new ConfigurationError('RSA keys only support usage: encrypt or sign');
     }
-  } else if (algorithm.startsWith('ec:')) {
-    const curve = algorithm.split(':')[1];
-    const namedCurve =
-      curve === 'secp256r1'
-        ? 'P-256'
-        : curve === 'secp384r1'
-          ? 'P-384'
-          : curve === 'secp521r1'
-            ? 'P-521'
-            : (() => {
-                throw new ConfigurationError(`Unsupported EC curve: ${curve}`);
-              })();
+  } else if (isEcKeyAlgorithm(algorithm)) {
+    const namedCurve = ecAlgorithmToCurve(algorithm);
 
     if (usage === 'derive') {
       cryptoAlgorithm = { name: 'ECDH', namedCurve };
@@ -344,7 +337,7 @@ export async function importPrivateKey(pem: string, options: KeyOptions): Promis
   let cryptoAlgorithm: RsaHashedImportParams | EcKeyImportParams;
   let keyUsages: KeyUsage[];
 
-  if (algorithm.startsWith('rsa:')) {
+  if (isRsaKeyAlgorithm(algorithm)) {
     if (usage === 'encrypt') {
       cryptoAlgorithm = rsaOaepSha1();
       keyUsages = ['decrypt'];
@@ -354,18 +347,8 @@ export async function importPrivateKey(pem: string, options: KeyOptions): Promis
     } else {
       throw new ConfigurationError('RSA keys only support usage: encrypt or sign');
     }
-  } else if (algorithm.startsWith('ec:')) {
-    const curve = algorithm.split(':')[1];
-    const namedCurve =
-      curve === 'secp256r1'
-        ? 'P-256'
-        : curve === 'secp384r1'
-          ? 'P-384'
-          : curve === 'secp521r1'
-            ? 'P-521'
-            : (() => {
-                throw new ConfigurationError(`Unsupported EC curve: ${curve}`);
-              })();
+  } else if (isEcKeyAlgorithm(algorithm)) {
+    const namedCurve = ecAlgorithmToCurve(algorithm);
 
     if (usage === 'derive') {
       cryptoAlgorithm = { name: 'ECDH', namedCurve };

--- a/lib/tdf3/src/crypto/core/keys.ts
+++ b/lib/tdf3/src/crypto/core/keys.ts
@@ -1,7 +1,11 @@
 import {
+  ecAlgorithmToCurve,
+  isEcKeyAlgorithm,
+  isRsaKeyAlgorithm,
   type KeyAlgorithm,
   type PrivateKey,
   type PublicKey,
+  rsaAlgorithmToModulusBits,
   type SymmetricKey,
 } from '../declarations.js';
 
@@ -15,18 +19,10 @@ export function wrapPublicKey(key: CryptoKey, algorithm: KeyAlgorithm): PublicKe
     algorithm,
     _internal: key,
   };
-  if (algorithm.startsWith('rsa:')) {
-    result.modulusBits = parseInt(algorithm.split(':')[1], 10);
-  } else if (algorithm.startsWith('ec:')) {
-    const curvePart = algorithm.split(':')[1];
-    result.curve =
-      curvePart === 'secp256r1'
-        ? 'P-256'
-        : curvePart === 'secp384r1'
-          ? 'P-384'
-          : curvePart === 'secp521r1'
-            ? 'P-521'
-            : undefined;
+  if (isRsaKeyAlgorithm(algorithm)) {
+    result.modulusBits = rsaAlgorithmToModulusBits(algorithm);
+  } else if (isEcKeyAlgorithm(algorithm)) {
+    result.curve = ecAlgorithmToCurve(algorithm);
   }
   return result as PublicKey;
 }
@@ -41,18 +37,10 @@ export function wrapPrivateKey(key: CryptoKey, algorithm: KeyAlgorithm): Private
     algorithm,
     _internal: key,
   };
-  if (algorithm.startsWith('rsa:')) {
-    result.modulusBits = parseInt(algorithm.split(':')[1], 10);
-  } else if (algorithm.startsWith('ec:')) {
-    const curvePart = algorithm.split(':')[1];
-    result.curve =
-      curvePart === 'secp256r1'
-        ? 'P-256'
-        : curvePart === 'secp384r1'
-          ? 'P-384'
-          : curvePart === 'secp521r1'
-            ? 'P-521'
-            : undefined;
+  if (isRsaKeyAlgorithm(algorithm)) {
+    result.modulusBits = rsaAlgorithmToModulusBits(algorithm);
+  } else if (isEcKeyAlgorithm(algorithm)) {
+    result.curve = ecAlgorithmToCurve(algorithm);
   }
   return result as PrivateKey;
 }

--- a/lib/tdf3/src/crypto/declarations.ts
+++ b/lib/tdf3/src/crypto/declarations.ts
@@ -21,23 +21,13 @@ export type PemKeyPair = {
   privateKey: string;
 };
 
-/**
- * Supported key algorithms, grouped by key-mechanism family. These `as const`
- * arrays are the single source of truth: the family subtypes, the combined
- * {@link KeyAlgorithm} union, and the runtime guards below all derive from them.
- */
 export const EC_KEY_ALGORITHMS = ['ec:secp256r1', 'ec:secp384r1', 'ec:secp521r1'] as const;
 export const RSA_KEY_ALGORITHMS = ['rsa:2048', 'rsa:4096'] as const;
 
-/**
- * All supported key algorithms. Order is significant: it is re-exported as
- * `PUBLIC_KEY_ALGORITHMS` from `access.ts`, which historically listed EC, then RSA.
- */
+/** Order is significant: re-exported as `PUBLIC_KEY_ALGORITHMS` in `access.ts` and consumed as an ordered list (e.g. CLI `--choices` output). */
 export const KEY_ALGORITHMS = [...EC_KEY_ALGORITHMS, ...RSA_KEY_ALGORITHMS] as const;
 
-/** Elliptic-curve key algorithm identifiers (`ec:*`). */
 export type EcKeyAlgorithm = (typeof EC_KEY_ALGORITHMS)[number];
-/** RSA key algorithm identifiers (`rsa:*`). */
 export type RsaKeyAlgorithm = (typeof RSA_KEY_ALGORITHMS)[number];
 
 /**
@@ -45,20 +35,12 @@ export type RsaKeyAlgorithm = (typeof RSA_KEY_ALGORITHMS)[number];
  */
 export type KeyAlgorithm = EcKeyAlgorithm | RsaKeyAlgorithm;
 
-/** Narrows a string to an elliptic-curve (`ec:*`) key algorithm. */
 export const isEcKeyAlgorithm = (a: string): a is EcKeyAlgorithm =>
   (EC_KEY_ALGORITHMS as readonly string[]).includes(a);
-/** Narrows a string to an RSA (`rsa:*`) key algorithm. */
 export const isRsaKeyAlgorithm = (a: string): a is RsaKeyAlgorithm =>
   (RSA_KEY_ALGORITHMS as readonly string[]).includes(a);
-/** Narrows a string to any supported key algorithm. */
 export const isKeyAlgorithm = (a: string): a is KeyAlgorithm =>
   (KEY_ALGORITHMS as readonly string[]).includes(a);
-
-// Strictly-typed accessors for the variant encoded in each family's algorithm
-// literal. The `Record<Subtype, …>` maps are exhaustive by construction — adding
-// a family member or mistyping a key is a compile error — so these avoid the
-// `parseInt`/`split(':')`/`as` patterns they replace.
 
 const EC_ALGORITHM_CURVES: Record<EcKeyAlgorithm, ECCurve> = {
   'ec:secp256r1': 'P-256',

--- a/lib/tdf3/src/crypto/declarations.ts
+++ b/lib/tdf3/src/crypto/declarations.ts
@@ -22,14 +22,59 @@ export type PemKeyPair = {
 };
 
 /**
+ * Supported key algorithms, grouped by key-mechanism family. These `as const`
+ * arrays are the single source of truth: the family subtypes, the combined
+ * {@link KeyAlgorithm} union, and the runtime guards below all derive from them.
+ */
+export const EC_KEY_ALGORITHMS = ['ec:secp256r1', 'ec:secp384r1', 'ec:secp521r1'] as const;
+export const RSA_KEY_ALGORITHMS = ['rsa:2048', 'rsa:4096'] as const;
+
+/**
+ * All supported key algorithms. Order is significant: it is re-exported as
+ * `PUBLIC_KEY_ALGORITHMS` from `access.ts`, which historically listed EC, then RSA.
+ */
+export const KEY_ALGORITHMS = [...EC_KEY_ALGORITHMS, ...RSA_KEY_ALGORITHMS] as const;
+
+/** Elliptic-curve key algorithm identifiers (`ec:*`). */
+export type EcKeyAlgorithm = (typeof EC_KEY_ALGORITHMS)[number];
+/** RSA key algorithm identifiers (`rsa:*`). */
+export type RsaKeyAlgorithm = (typeof RSA_KEY_ALGORITHMS)[number];
+
+/**
  * Key algorithm identifier combining key type and parameters.
  */
-export type KeyAlgorithm =
-  | 'rsa:2048'
-  | 'rsa:4096'
-  | 'ec:secp256r1'
-  | 'ec:secp384r1'
-  | 'ec:secp521r1';
+export type KeyAlgorithm = EcKeyAlgorithm | RsaKeyAlgorithm;
+
+/** Narrows a string to an elliptic-curve (`ec:*`) key algorithm. */
+export const isEcKeyAlgorithm = (a: string): a is EcKeyAlgorithm =>
+  (EC_KEY_ALGORITHMS as readonly string[]).includes(a);
+/** Narrows a string to an RSA (`rsa:*`) key algorithm. */
+export const isRsaKeyAlgorithm = (a: string): a is RsaKeyAlgorithm =>
+  (RSA_KEY_ALGORITHMS as readonly string[]).includes(a);
+/** Narrows a string to any supported key algorithm. */
+export const isKeyAlgorithm = (a: string): a is KeyAlgorithm =>
+  (KEY_ALGORITHMS as readonly string[]).includes(a);
+
+// Strictly-typed accessors for the variant encoded in each family's algorithm
+// literal. The `Record<Subtype, …>` maps are exhaustive by construction — adding
+// a family member or mistyping a key is a compile error — so these avoid the
+// `parseInt`/`split(':')`/`as` patterns they replace.
+
+const EC_ALGORITHM_CURVES: Record<EcKeyAlgorithm, ECCurve> = {
+  'ec:secp256r1': 'P-256',
+  'ec:secp384r1': 'P-384',
+  'ec:secp521r1': 'P-521',
+};
+/** The elliptic curve for an `ec:*` key algorithm. */
+export const ecAlgorithmToCurve = (alg: EcKeyAlgorithm): ECCurve => EC_ALGORITHM_CURVES[alg];
+
+const RSA_ALGORITHM_MODULUS_BITS: Record<RsaKeyAlgorithm, 2048 | 4096> = {
+  'rsa:2048': 2048,
+  'rsa:4096': 4096,
+};
+/** The modulus bit length for an `rsa:*` key algorithm. */
+export const rsaAlgorithmToModulusBits = (alg: RsaKeyAlgorithm): 2048 | 4096 =>
+  RSA_ALGORITHM_MODULUS_BITS[alg];
 
 /**
  * Options for key generation and import.
@@ -156,7 +201,7 @@ export type HkdfParams = {
  */
 export type PublicKeyInfo = {
   /** Detected algorithm of the key. */
-  algorithm: 'rsa:2048' | 'rsa:4096' | 'ec:secp256r1' | 'ec:secp384r1' | 'ec:secp521r1';
+  algorithm: KeyAlgorithm;
   /** Normalized PEM string. */
   pem: string;
 };


### PR DESCRIPTION
## What

Extracts the **EC/RSA key-algorithm type refactor** that had accreted onto the ML-KEM feature PR #933 (DSPX-3229) into its own reviewable/rollback-able change off `main`. No ML-KEM here — that stays on #933, which will rebase on top of this.

- **`crypto/declarations.ts`** is now the single source of truth for key algorithms: per-family `as const` arrays (`EC_KEY_ALGORITHMS`, `RSA_KEY_ALGORITHMS`, `KEY_ALGORITHMS`), derived subtypes (`EcKeyAlgorithm`/`RsaKeyAlgorithm`), runtime guards (`isEcKeyAlgorithm`/`isRsaKeyAlgorithm`/`isKeyAlgorithm`), and exhaustive typed accessors (`ecAlgorithmToCurve`/`rsaAlgorithmToModulusBits`).
- Call sites (`dpop.ts`, `crypto/core/keys.ts`, `crypto/core/key-format.ts`, `client/index.ts`) drop `startsWith('ec:'|'rsa:')` / `split(':')` / curve ternaries in favor of the guards and accessors.
- `access.ts` re-exports the historic surface as thin aliases over the source of truth: `PUBLIC_KEY_ALGORITHMS = KEY_ALGORITHMS`, `KasPublicKeyAlgorithm = KeyAlgorithm`, `isPublicKeyAlgorithm = isKeyAlgorithm`. `PUBLIC_KEY_ALGORITHMS` is exported from the public entrypoint.
- CLI: `encapKeyType` / `rewrapKeyType` gain `choices: PUBLIC_KEY_ALGORITHMS`, so unsupported values are rejected up front with the valid list.

## Why

Mixing a broad type refactor with the ML-KEM feature made #933 hard to review and hard to roll back. Landing the feature-independent slice on its own keeps each change reviewable and independently revertable.

## Bug fix (intentional behavior change)

`isPublicKeyAlgorithm` previously accepted **only** `ec:secp256r1` / `rsa:2048` and wrongly rejected `ec:secp384r1`, `ec:secp521r1`, `rsa:4096`. It now delegates to `isKeyAlgorithm` and accepts all supported EC/RSA algorithms.

Consequence: the CLI now offers all 5 as `choices`, but client-side **wrapping** still supports only a subset (`ec:secp256r1`, `rsa:2048`); unsupported picks now fail at wrap time rather than at arg-parse time.

## How to test

- `cd lib && npm run build && npm run lint && npm test` — green (334 tests, coverage thresholds met); `.d.ts` gains `PUBLIC_KEY_ALGORITHMS` / subtypes / accessors, `KasPublicKeyAlgorithm` + `isPublicKeyAlgorithm` still exported.
- `make i` then `cd cli && npm run build && npm test` — green.
- `isPublicKeyAlgorithm('ec:secp384r1')` and `('rsa:4096')` now return `true`.
- `opentdf encrypt --encapsulation-algorithm rsa:9999 …` is rejected up front with the choices list; `ec:secp384r1` is accepted.

## Scope / risk

Out of scope: all ML-KEM types/guards/accessors/KAO and edits to `tdf.ts` / `key-access.ts` / tests (those are ML-KEM-only on #933). Touches crypto type plumbing — see the bug-fix note above.

DSPX-4040


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a shared list of supported public-key algorithms for SDK and CLI consumers.
  - Exposed algorithm lists and validation helpers for RSA and elliptic-curve keys.
  - CLI encryption and rewrapping options now provide validation for supported algorithms.

- **Bug Fixes**
  - Improved key import, wrapping, and DPoP handling across supported RSA and elliptic-curve algorithms.
  - Added clearer validation for unsupported or invalid key algorithms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->