### PR TITLE
fix(sdk): thread wrappingKeyAlgorithm through decrypt rewrap

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -667,6 +667,12 @@ export const handleArgs = (args: string[]) => {
         JSON.stringify({
           '@opentdf/sdk': version,
           tdfSpecVersion,
+          // Features explicitly implemented by this CLI build, as opposed to
+          // values merely accepted by an option's `choices` list (e.g.
+          // --rewrapKeyType has long accepted "mlkem:768" because it shares
+          // PUBLIC_KEY_ALGORITHMS with the KAS-managed-key encap path, which
+          // predates the rewrap session key actually decapsulating ML-KEM).
+          supportedFeatures: ['session-key-mlkem'],
         })
       )
       .alias('version', 'V')

--- a/lib/tdf3/src/tdf.ts
+++ b/lib/tdf3/src/tdf.ts
@@ -1410,6 +1410,7 @@ export async function decryptStreamFrom(
     allowedKases: allowList,
     dpopKeys: cfg.dpopKeys,
     cryptoService: cfg.cryptoService,
+    wrappingKeyAlgorithm: cfg.wrappingKeyAlgorithm,
   });
   // async function unwrapKey(manifest: Manifest, allowedKases: string[], authProvider: AuthProvider | AppIdAuthProvider, publicKey: string, privateKey: string, entity: EntityObject) {
   const keyForDecryption = await cfg.keyMiddleware(reconstructedKey);

--- a/lib/tests/server.ts
+++ b/lib/tests/server.ts
@@ -438,7 +438,7 @@ const kas: RequestListener = async (req, res) => {
             name: 'ECDH',
             namedCurve: 'P-256',
           },
-          false,
+          true,
           ['deriveBits', 'deriveKey']
         );
         const kek = await keyAgreement(sessionKeyPair.privateKey, clientPublicKey!, {
@@ -450,7 +450,15 @@ const kas: RequestListener = async (req, res) => {
         const entityWrappedKey = new Uint8Array(iv.length + cek.byteLength);
         entityWrappedKey.set(iv);
         entityWrappedKey.set(new Uint8Array(cek), iv.length);
+        // The client needs the KAS's ephemeral EC public key to complete its own
+        // ECDH derivation; without this the client can never recompute `kek`.
+        const sessionPublicKeySpki = await crypto.subtle.exportKey(
+          'spki',
+          sessionKeyPair.publicKey
+        );
+        const sessionPublicKey = formatAsPem(sessionPublicKeySpki, 'PUBLIC KEY');
         const reply = create(RewrapResponseSchema, {
+          sessionPublicKey,
           responses: [
             create(PolicyRewrapResultSchema, {
               results: [


### PR DESCRIPTION
## Summary

Found while cross-SDK testing DSPX-4221 (Session Keys should support ML-KEM) against a live modified platform. `decryptStreamFrom()` builds its `DecryptConfiguration` with `wrappingKeyAlgorithm` (threaded in from both `Client.decrypt()` and the newer `OpenTDF.read()` CLI path), but never forwards it to the internal `unwrapKey()` call that actually builds the rewrap request:

```ts
const { metadata, reconstructedKey, requiredObligations } = await unwrapKey({
  fulfillableObligations: cfg.fulfillableObligations,
  manifest,
  auth: cfg.auth,
  allowedKases: allowList,
  dpopKeys: cfg.dpopKeys,
  cryptoService: cfg.cryptoService,
  // wrappingKeyAlgorithm: cfg.wrappingKeyAlgorithm,  <-- missing
});
```

`unwrapKey()`/`tryKasRewrap()` already correctly branch on `wrappingKeyAlgorithm` to generate EC/RSA/ML-KEM ephemeral session keys — the parameter was just silently dropped one call site up. **Every decrypt call ignored whatever `rewrapKeyType`/`wrappingKeyAlgorithm` the caller requested and always negotiated RSA**, regardless of CLI flag or API option.

## How this was found

The OpenTDF platform's rewrap audit log now records `eventMetaData.sessionKeyType` (opentdf/platform#3814, part of this same DSPX-4221 effort). Running the xtest suite's new `test_session_key_mlkem_roundtrip` (opentdf/tests#571) against a real platform + this SDK's CLI showed the audit log recording `"sessionKeyType":"rsa:2048"` even when the test explicitly passed `--rewrapKeyType mlkem:768`.

The existing unit tests in `lib/tests/mocha/encrypt-decrypt.spec.ts` (parametrized across `{encap, rewrap}` algorithm pairs) didn't catch this: the mock KAS server just echoes back whatever `clientPublicKey` type it actually receives and validates consistently against *that*, so a client silently ignoring the requested algorithm and the mock server never disagree — the bug was fully masked at the unit-test layer. It only surfaced against a real server that independently records what it actually saw.

## Second bug surfaced by the fix

Fixing the plumbing caused 4 previously-passing mock unit tests to start failing — all four `{*, rewrap: ec:secp256r1}` combinations. That's because `lib/tests/server.ts`'s mock KAS EC-rewrap branch generates an ephemeral ECDH key pair server-side but never returned its public half (`sessionPublicKey`) in the response, which the client needs to complete its own ECDH derivation. This EC session-key path was never actually exercised by the unit suite before (same masking bug as above), so it was silently broken too. Fixed by exporting and returning the server's ephemeral public key.

## Test plan

```
cd lib
npm run build
npm run lint
npx prettier --check tdf3/src/tdf.ts tests/server.ts
node dist/web/tests/server.js &   # mock KAS
npx mocha "dist/web/tests/mocha/**/*.spec.js" --timeout 60000
```
366 passing, 0 failing.

**Confirmed against a live local platform** (built from opentdf/platform#3814, with Go SDK from that same PR and Java SDK from opentdf/java-sdk#388), running opentdf/tests#571's `test_session_key_mlkem_roundtrip` with this branch's JS SDK across the full encrypt×decrypt matrix:

```
18 passed (go×go, go×java, go×js, java×go, java×java, java×js, js×go, js×java, js×js — each ×768/×1024)
```
All with real audit-log verification enabled (`audit_logs.assert_rewrap_success(session_key_type=...)`), confirming the platform genuinely negotiated the requested ML-KEM algorithm end-to-end, not just that decrypt happened to succeed.

## Related work

Part of the DSPX-4221 series:
- opentdf/tests#571
- opentdf/platform#3814
- opentdf/java-sdk#388

Ref: DSPX-4221

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CLI version information now reports support for session-key ML-KEM.
  * Rewrap responses now include the session public key needed for client-side key derivation.

* **Bug Fixes**
  * Configured wrapping-key algorithms are now honored during stream decryption and key rewrapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->