### PR TITLE
fix(sdk): bump js-yaml to 3.15.1/4.3.1 in lib to patch omap DoS

### DIFF
--- a/lib/package-lock.json
+++ b/lib/package-lock.json
@@ -1426,9 +1426,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7440,9 +7440,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Patches the last two open Dependabot alerts in the repo. Merging this takes `opentdf/web-sdk` to **zero open Dependabot alerts**.

## The vulnerability

[GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj) / CVE-2026-59870 — **js-yaml: quadratic CPU consumption in `!!omap` resolution**. A crafted YAML document using ordered-map tags can be made to consume CPU quadratic in its size. Rated high; alerts [#327](https://github.com/opentdf/web-sdk/security/dependabot/327) and [#328](https://github.com/opentdf/web-sdk/security/dependabot/328), both against `lib/package-lock.json`.

The 4.x and 3.x lines were patched separately, and this repo transitively pulls in both.

## The change

One file, six lines, `lib/package-lock.json`:

| Path | From | To | Pulled in by |
|---|---|---|---|
| `node_modules/js-yaml` | 4.3.0 | **4.3.1** | `eslint`, `@eslint/eslintrc`, `mocha` (all `^4.1.0`) |
| `node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml` | 3.15.0 | **3.15.1** | `nyc` → `@istanbuljs/load-nyc-config` (`^3.13.1`) |

Both new versions already satisfy the existing ranges, so no `package.json` is touched. Produced with:

```
cd lib && npm update js-yaml --package-lock-only
```

## Scope

`js-yaml` reaches this repo only through `eslint`, `mocha` and `nyc` — all `devDependencies`. It is not part of the published `@opentdf/sdk` artifact and no runtime code path can reach it. `cli/` and `web-app/` are untouched; they were patched separately by #981 and #983.

## Verification

- `cd lib && npm ci --include=dev && npm test` — passes: mocha + web-test-runner + 366 Karma browser tests, coverage thresholds met.
- `cd lib && npm audit` — `js-yaml` no longer reported.
- `cd lib && npm install --package-lock-only` — no further drift, so the lockfile is canonical rather than a hand-edited or merge-resolved artifact.
- All 28 CI checks green.

## Risk

Low. Patch-level bump of a dev-only transitive dependency. Worst case is a lint/test tooling regression, which CI would surface directly.

## Related

This branch originally bundled `brace-expansion` and `js-yaml` fixes across all three packages, because Dependabot had filed alerts without opening PRs. Dependabot has since produced its own PRs for all of them — #981, #983, #985, #995 — and each was rebased out of this branch as it merged. What remains is the one alert Dependabot never generated a PR for.

## Known gaps, out of scope

`npm audit` additionally reports `nanoid` (high) and `body-parser` (low) in `lib/`, and `ajv` (moderate) in `web-app/`. None of the three has an open Dependabot alert, so they are deliberately excluded to keep this PR to the alerted change. Worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)