### PR TITLE
fix(sdk): emit RFC 7518 raw ECDSA signatures in JWS (DSPX-3397)

### DIFF
--- a/lib/src/auth/dpop.ts
+++ b/lib/src/auth/dpop.ts
@@ -41,16 +41,9 @@ async function jwt(
 ) {
   const input = `${b64u(buf(JSON.stringify(header)))}.${b64u(buf(JSON.stringify(claimsSet)))}`;
   const { alg } = header;
-  // The header alg is a JWSAlgorithm, which is wider than what CryptoService can
-  // actually sign with (it documents forward-looking values like PS256/EdDSA).
-  // Validate rather than blind-cast so an unsupported alg fails here with a clear
-  // error instead of surfacing deep inside getSigningAlgorithmParams.
   if (!isAsymmetricSigningAlgorithm(alg)) {
     throw new UnsupportedOperationError(`unsupported DPoP alg: ${alg}`);
   }
-  // CryptoService.sign returns raw IEEE P1363 (R || S) for ECDSA per RFC 7518
-  // §3.4, which is what RFC-conformant verifiers (Keycloak, panva-jose) expect
-  // of a DPoP proof.
   const signature = await cryptoService.sign(buf(input), privateKey, alg);
   return `${input}.${b64u(signature)}`;
 }
@@ -131,7 +124,7 @@ class UnsupportedOperationError extends Error {
 /**
  * Determines a supported JWS `alg` identifier from PublicKeyInfo algorithm string.
  * Returns an AsymmetricSigningAlgorithm (the subset CryptoService can sign with);
- * it never produces the forward-looking PS256/EdDSA members of JWSAlgorithm.
+ * notably, it does not support PS256/EdDSA members of JWSAlgorithm.
  */
 function determineJWSAlgorithmFromKeyInfo(algorithm: KeyAlgorithm): AsymmetricSigningAlgorithm {
   if (isRsaKeyAlgorithm(algorithm)) {

--- a/lib/src/auth/dpop.ts
+++ b/lib/src/auth/dpop.ts
@@ -8,7 +8,10 @@ import type {
   AsymmetricSigningAlgorithm,
   KeyAlgorithm,
 } from '../../tdf3/src/crypto/declarations.js';
-import { isRsaKeyAlgorithm } from '../../tdf3/src/crypto/declarations.js';
+import {
+  isAsymmetricSigningAlgorithm,
+  isRsaKeyAlgorithm,
+} from '../../tdf3/src/crypto/declarations.js';
 
 export type JsonObject = { [Key in string]?: JsonValue };
 export type JsonArray = JsonValue[];
@@ -21,11 +24,11 @@ function buf(input: string): Uint8Array {
   return encoder.encode(input);
 }
 
-interface DPoPJwtHeaderParameters {
+type DPoPJwtHeaderParameters = {
   alg: JWSAlgorithm;
-  typ: string;
+  typ: 'dpop+jwt';
   jwk: JsonWebKey;
-}
+};
 
 /**
  * Minimal JWT sign() implementation using CryptoService.
@@ -37,11 +40,18 @@ async function jwt(
   cryptoService: CryptoService
 ) {
   const input = `${b64u(buf(JSON.stringify(header)))}.${b64u(buf(JSON.stringify(claimsSet)))}`;
-  const signature = await cryptoService.sign(
-    buf(input),
-    privateKey,
-    header.alg as AsymmetricSigningAlgorithm
-  );
+  const { alg } = header;
+  // The header alg is a JWSAlgorithm, which is wider than what CryptoService can
+  // actually sign with (it documents forward-looking values like PS256/EdDSA).
+  // Validate rather than blind-cast so an unsupported alg fails here with a clear
+  // error instead of surfacing deep inside getSigningAlgorithmParams.
+  if (!isAsymmetricSigningAlgorithm(alg)) {
+    throw new UnsupportedOperationError(`unsupported DPoP alg: ${alg}`);
+  }
+  // CryptoService.sign returns raw IEEE P1363 (R || S) for ECDSA per RFC 7518
+  // §3.4, which is what RFC-conformant verifiers (Keycloak, panva-jose) expect
+  // of a DPoP proof.
+  const signature = await cryptoService.sign(buf(input), privateKey, alg);
   return `${input}.${b64u(signature)}`;
 }
 
@@ -120,8 +130,10 @@ class UnsupportedOperationError extends Error {
 
 /**
  * Determines a supported JWS `alg` identifier from PublicKeyInfo algorithm string.
+ * Returns an AsymmetricSigningAlgorithm (the subset CryptoService can sign with);
+ * it never produces the forward-looking PS256/EdDSA members of JWSAlgorithm.
  */
-function determineJWSAlgorithmFromKeyInfo(algorithm: KeyAlgorithm): JWSAlgorithm {
+function determineJWSAlgorithmFromKeyInfo(algorithm: KeyAlgorithm): AsymmetricSigningAlgorithm {
   if (isRsaKeyAlgorithm(algorithm)) {
     return 'RS256';
   }

--- a/lib/tdf3/src/assertions.ts
+++ b/lib/tdf3/src/assertions.ts
@@ -111,7 +111,8 @@ async function sign(
   try {
     token = await signJwt(cryptoService, payload, signingMaterial, header);
   } catch (error) {
-    throw new ConfigurationError(`Signing assertion failed: ${error.message}`, error);
+    const msg = error instanceof Error ? error.message : String(error);
+    throw new ConfigurationError(`Signing assertion failed: ${msg}`, error);
   }
   thiz.binding.method = 'jws';
   thiz.binding.signature = token;
@@ -185,7 +186,8 @@ export async function verify(
     });
     payload = result.payload as AssertionPayload;
   } catch (error) {
-    throw new InvalidFileError(`Verifying assertion failed: ${error.message}`, error);
+    const msg = error instanceof Error ? error.message : String(error);
+    throw new InvalidFileError(`Verifying assertion failed: ${msg}`, error);
   }
   const { assertionHash, assertionSig } = payload;
 

--- a/lib/tdf3/src/crypto/core/signing.ts
+++ b/lib/tdf3/src/crypto/core/signing.ts
@@ -40,140 +40,12 @@ function getSigningAlgorithmParams(algorithm: AsymmetricSigningAlgorithm): {
 }
 
 /**
- * Convert IEEE P1363 signature format (used by WebCrypto ECDSA) to DER format (used by JWT).
- * RS256 signatures don't need conversion.
- */
-function ieeeP1363ToDer(signature: Uint8Array, algorithm: AsymmetricSigningAlgorithm): Uint8Array {
-  if (algorithm === 'RS256') {
-    return signature;
-  }
-
-  // IEEE P1363: r || s where each is padded to key size
-  const halfLen = signature.length / 2;
-  const r = signature.slice(0, halfLen);
-  const s = signature.slice(halfLen);
-
-  // Remove leading zeros but keep one if the high bit is set
-  const trimLeadingZeros = (arr: Uint8Array): Uint8Array => {
-    let i = 0;
-    while (i < arr.length - 1 && arr[i] === 0) i++;
-    return arr.slice(i);
-  };
-
-  let rTrimmed = trimLeadingZeros(r);
-  let sTrimmed = trimLeadingZeros(s);
-
-  // Add leading zero if high bit is set (to keep positive in DER)
-  if (rTrimmed[0] & 0x80) {
-    const padded = new Uint8Array(rTrimmed.length + 1);
-    padded.set(rTrimmed, 1);
-    rTrimmed = padded;
-  }
-  if (sTrimmed[0] & 0x80) {
-    const padded = new Uint8Array(sTrimmed.length + 1);
-    padded.set(sTrimmed, 1);
-    sTrimmed = padded;
-  }
-
-  // DER SEQUENCE: 0x30 [length] [r INTEGER] [s INTEGER]
-  // INTEGER: 0x02 [length] [value]
-  const rDer = new Uint8Array([0x02, rTrimmed.length, ...rTrimmed]);
-  const sDer = new Uint8Array([0x02, sTrimmed.length, ...sTrimmed]);
-
-  const seqLen = rDer.length + sDer.length;
-  // DER length: short-form for < 128, long-form (0x81 nn) for 128-255.
-  // ECDSA sequences never exceed 255 bytes for any supported curve.
-  const lenBytes = seqLen < 128 ? new Uint8Array([seqLen]) : new Uint8Array([0x81, seqLen]);
-  const result = new Uint8Array(1 + lenBytes.length + seqLen);
-  result[0] = 0x30;
-  result.set(lenBytes, 1);
-  result.set(rDer, 1 + lenBytes.length);
-  result.set(sDer, 1 + lenBytes.length + rDer.length);
-
-  return result;
-}
-
-/**
- * Convert DER signature format (used by JWT) to IEEE P1363 format (used by WebCrypto ECDSA).
- * RS256 signatures don't need conversion.
- */
-function derToIeeeP1363(signature: Uint8Array, algorithm: AsymmetricSigningAlgorithm): Uint8Array {
-  if (algorithm === 'RS256') {
-    return signature;
-  }
-
-  // Determine the expected component length based on algorithm
-  let componentLen: number;
-  switch (algorithm) {
-    case 'ES256':
-      componentLen = 32;
-      break;
-    case 'ES384':
-      componentLen = 48;
-      break;
-    case 'ES512':
-      componentLen = 66;
-      break;
-    default:
-      throw new ConfigurationError(`Unsupported algorithm for DER conversion: ${algorithm}`);
-  }
-
-  if (signature[0] !== 0x30) {
-    throw new ConfigurationError('Invalid DER signature: expected SEQUENCE');
-  }
-
-  // Skip SEQUENCE tag, then parse DER length (short- or long-form).
-  let offset = 1;
-  if (signature[offset] & 0x80) {
-    // Long-form: low 7 bits = number of subsequent length bytes.
-    const lenBytesCount = signature[offset] & 0x7f;
-    if (lenBytesCount === 0 || lenBytesCount > 4) {
-      throw new ConfigurationError('Invalid DER signature: invalid long-form length');
-    }
-    offset += 1 + lenBytesCount;
-    if (offset > signature.length) {
-      throw new ConfigurationError('Invalid DER signature: length bytes exceed signature length');
-    }
-  } else {
-    // Short-form: single length byte.
-    offset += 1;
-  }
-
-  // Parse r INTEGER
-  if (signature[offset] !== 0x02) {
-    throw new ConfigurationError('Invalid DER signature: expected INTEGER for r');
-  }
-  const rLen = signature[offset + 1];
-  offset += 2;
-  let r = signature.slice(offset, offset + rLen);
-  offset += rLen;
-
-  // Parse s INTEGER
-  if (signature[offset] !== 0x02) {
-    throw new ConfigurationError('Invalid DER signature: expected INTEGER for s');
-  }
-  const sLen = signature[offset + 1];
-  offset += 2;
-  let s = signature.slice(offset, offset + sLen);
-
-  // Remove leading zero padding if present
-  if (r[0] === 0 && r.length > componentLen) {
-    r = r.slice(1);
-  }
-  if (s[0] === 0 && s.length > componentLen) {
-    s = s.slice(1);
-  }
-
-  // Pad to component length
-  const result = new Uint8Array(componentLen * 2);
-  result.set(r, componentLen - r.length);
-  result.set(s, componentLen * 2 - s.length);
-
-  return result;
-}
-
-/**
  * Sign data with an asymmetric private key.
+ *
+ * ECDSA signatures come back as raw IEEE P1363 (`R || S`) — the fixed-width
+ * encoding WebCrypto emits and the one RFC 7518 section 3.4 requires on the JWS
+ * wire — so nothing transcodes between here and the token. RSA signatures have
+ * a single encoding.
  */
 export async function sign(
   data: Uint8Array,
@@ -185,15 +57,14 @@ export async function sign(
   // Unwrap the internal CryptoKey
   const key = unwrapKey(privateKey);
 
-  // Sign the data
-  const signature = await crypto.subtle.sign(signParams, key, data);
-
-  // Convert from IEEE P1363 to DER for EC algorithms
-  return ieeeP1363ToDer(new Uint8Array(signature), algorithm);
+  return new Uint8Array(await crypto.subtle.sign(signParams, key, data));
 }
 
 /**
  * Verify signature with an asymmetric public key.
+ *
+ * Expects the encoding {@link sign} produces: raw IEEE P1363 for ECDSA. A
+ * wrong-length signature fails verification rather than throwing.
  */
 export async function verify(
   data: Uint8Array,
@@ -206,9 +77,5 @@ export async function verify(
   // Unwrap the internal CryptoKey
   const key = unwrapKey(publicKey);
 
-  // Convert from DER to IEEE P1363 for EC algorithms
-  const ieeeSignature = derToIeeeP1363(signature, algorithm);
-
-  // Verify the signature
-  return crypto.subtle.verify(signParams, key, ieeeSignature, data);
+  return crypto.subtle.verify(signParams, key, signature, data);
 }

--- a/lib/tdf3/src/crypto/declarations.ts
+++ b/lib/tdf3/src/crypto/declarations.ts
@@ -206,9 +206,7 @@ export type AsymmetricSigningAlgorithm = (typeof ASYMMETRIC_SIGNING_ALGORITHMS)[
 
 /**
  * Type guard narrowing an arbitrary string to an algorithm CryptoService can
- * actually sign/verify with. The JWS `alg` space is wider (e.g. forward-looking
- * PS256/EdDSA identifiers) than this runtime-supported subset; those must be
- * rejected, not cast.
+ * sign/verify with.
  */
 export function isAsymmetricSigningAlgorithm(alg: string): alg is AsymmetricSigningAlgorithm {
   return (ASYMMETRIC_SIGNING_ALGORITHMS as readonly string[]).includes(alg);
@@ -312,12 +310,10 @@ export type CryptoService = {
   /**
    * Sign data with an asymmetric private key.
    *
-   * ECDSA signature encoding: implementations MUST return raw IEEE P1363
-   * (`R || S`), fixed-width per curve — 64 bytes for ES256, 96 for ES384, 132
-   * for ES512. This is what WebCrypto emits and what RFC 7518 §3.4 requires on
-   * the JWS wire; the SDK writes the bytes through unchanged. An implementation
-   * returning ASN.1 DER will produce tokens that conformant verifiers reject.
-   * RSA signatures have a single encoding.
+   * ECDSA signature encoding: returns raw IEEE P1363 (`R || S`), fixed-width
+   * per curve — 64 bytes for ES256, 96 for ES384, 132 for ES512.
+   *
+   * RSA uses RSASSA-PKCS1-v1_5 with SHA-256.
    *
    * @param data - Data to sign
    * @param privateKey - Opaque private key
@@ -331,10 +327,6 @@ export type CryptoService = {
 
   /**
    * Verify signature with an asymmetric public key.
-   *
-   * ECDSA signature encoding: the SDK passes raw IEEE P1363 (`R || S`) — the
-   * same encoding {@link CryptoService.sign} produces, taken straight off the
-   * JWS wire. A wrong-length signature should fail verification, not throw.
    *
    * @param data - Original data that was signed
    * @param signature - Signature to verify

--- a/lib/tdf3/src/crypto/declarations.ts
+++ b/lib/tdf3/src/crypto/declarations.ts
@@ -186,9 +186,33 @@ export type SymmetricKey = {
 export type ECCurve = 'P-256' | 'P-384' | 'P-521';
 
 /**
+ * ECDSA signing algorithms. Signatures for these are raw IEEE P1363 (`R || S`)
+ * everywhere in this SDK, per RFC 7518 §3.4; see `crypto/core/signing.ts`.
+ */
+export const EC_SIGNING_ALGORITHMS = ['ES256', 'ES384', 'ES512'] as const;
+
+export type EcSigningAlgorithm = (typeof EC_SIGNING_ALGORITHMS)[number];
+
+/**
+ * Runtime list of asymmetric signing algorithms. Used to validate
+ * untyped/JWS-header algorithm strings.
+ */
+export const ASYMMETRIC_SIGNING_ALGORITHMS = ['RS256', ...EC_SIGNING_ALGORITHMS] as const;
+
+/**
  * Asymmetric signing algorithms (require PEM keys).
  */
-export type AsymmetricSigningAlgorithm = 'RS256' | 'ES256' | 'ES384' | 'ES512';
+export type AsymmetricSigningAlgorithm = (typeof ASYMMETRIC_SIGNING_ALGORITHMS)[number];
+
+/**
+ * Type guard narrowing an arbitrary string to an algorithm CryptoService can
+ * actually sign/verify with. The JWS `alg` space is wider (e.g. forward-looking
+ * PS256/EdDSA identifiers) than this runtime-supported subset; those must be
+ * rejected, not cast.
+ */
+export function isAsymmetricSigningAlgorithm(alg: string): alg is AsymmetricSigningAlgorithm {
+  return (ASYMMETRIC_SIGNING_ALGORITHMS as readonly string[]).includes(alg);
+}
 
 /**
  * Symmetric signing algorithm (requires raw key bytes).
@@ -287,6 +311,14 @@ export type CryptoService = {
 
   /**
    * Sign data with an asymmetric private key.
+   *
+   * ECDSA signature encoding: implementations MUST return raw IEEE P1363
+   * (`R || S`), fixed-width per curve — 64 bytes for ES256, 96 for ES384, 132
+   * for ES512. This is what WebCrypto emits and what RFC 7518 §3.4 requires on
+   * the JWS wire; the SDK writes the bytes through unchanged. An implementation
+   * returning ASN.1 DER will produce tokens that conformant verifiers reject.
+   * RSA signatures have a single encoding.
+   *
    * @param data - Data to sign
    * @param privateKey - Opaque private key
    * @param algorithm - Signing algorithm (RS256, ES256, ES384, ES512)
@@ -299,6 +331,11 @@ export type CryptoService = {
 
   /**
    * Verify signature with an asymmetric public key.
+   *
+   * ECDSA signature encoding: the SDK passes raw IEEE P1363 (`R || S`) — the
+   * same encoding {@link CryptoService.sign} produces, taken straight off the
+   * JWS wire. A wrong-length signature should fail verification, not throw.
+   *
    * @param data - Original data that was signed
    * @param signature - Signature to verify
    * @param publicKey - Opaque public key

--- a/lib/tdf3/src/crypto/jwt.ts
+++ b/lib/tdf3/src/crypto/jwt.ts
@@ -137,8 +137,6 @@ export async function signJwt(
     if (!isAsymmetricSigningAlgorithm(header.alg)) {
       throw new Error(`Unsupported JWS signing algorithm: ${header.alg}`);
     }
-    // CryptoService.sign returns exactly what the JWS wire wants: raw IEEE
-    // P1363 (R || S) for ECDSA per RFC 7518 §3.4, and PKCS#1 for RSA.
     signature = await cryptoService.sign(signingInputBytes, key, header.alg);
   }
 
@@ -236,8 +234,7 @@ export async function verifyJwt(
     if (!isAsymmetricSigningAlgorithm(header.alg)) {
       throw new joseErrors.JWTInvalid(`Invalid JWT: unsupported algorithm "${header.alg}"`);
     }
-    // The signature comes off the wire in the encoding CryptoService.verify
-    // expects: raw IEEE P1363 for ECDSA (RFC 7518 §3.4), PKCS#1 for RSA.
+    // Sigs are IEEE P1363 for ECDSA (RFC 7518 §3.4), PKCS#1 for RSA.
     valid = await cryptoService.verify(signingInputBytes, signature, publicKey, header.alg);
   }
 

--- a/lib/tdf3/src/crypto/jwt.ts
+++ b/lib/tdf3/src/crypto/jwt.ts
@@ -1,5 +1,5 @@
 import {
-  type AsymmetricSigningAlgorithm,
+  isAsymmetricSigningAlgorithm,
   type CryptoService,
   type PrivateKey,
   type PublicKey,
@@ -134,11 +134,12 @@ export async function signJwt(
     if (key._brand !== 'PrivateKey') {
       throw new Error(`${header.alg} requires a PrivateKey`);
     }
-    signature = await cryptoService.sign(
-      signingInputBytes,
-      key,
-      header.alg as AsymmetricSigningAlgorithm
-    );
+    if (!isAsymmetricSigningAlgorithm(header.alg)) {
+      throw new Error(`Unsupported JWS signing algorithm: ${header.alg}`);
+    }
+    // CryptoService.sign returns exactly what the JWS wire wants: raw IEEE
+    // P1363 (R || S) for ECDSA per RFC 7518 §3.4, and PKCS#1 for RSA.
+    signature = await cryptoService.sign(signingInputBytes, key, header.alg);
   }
 
   // Return compact JWT
@@ -232,12 +233,12 @@ export async function verifyJwt(
       typeof key === 'string'
         ? await cryptoService.importPublicKey(key, { usage: 'sign' })
         : (key as PublicKey);
-    valid = await cryptoService.verify(
-      signingInputBytes,
-      signature,
-      publicKey,
-      header.alg as AsymmetricSigningAlgorithm
-    );
+    if (!isAsymmetricSigningAlgorithm(header.alg)) {
+      throw new joseErrors.JWTInvalid(`Invalid JWT: unsupported algorithm "${header.alg}"`);
+    }
+    // The signature comes off the wire in the encoding CryptoService.verify
+    // expects: raw IEEE P1363 for ECDSA (RFC 7518 §3.4), PKCS#1 for RSA.
+    valid = await cryptoService.verify(signingInputBytes, signature, publicKey, header.alg);
   }
 
   if (!valid) {

--- a/lib/tdf3/src/tdf.ts
+++ b/lib/tdf3/src/tdf.ts
@@ -38,9 +38,11 @@ import { SymmetricCipher } from './ciphers/symmetric-cipher-base.js';
 import { DecryptParams } from './client/builders.js';
 import { DecoratedReadableStream } from './client/DecoratedReadableStream.js';
 import {
+  type AsymmetricSigningAlgorithm,
   type CryptoService,
   type DecryptResult,
   isMlKemKeyAlgorithm,
+  type KeyAlgorithm,
   type KeyPair,
   mlKemAlgorithmToLevel,
   type SymmetricKey,
@@ -757,6 +759,27 @@ type RewrapResponseData = {
   requiredObligations: string[];
 };
 
+/**
+ * Map an opaque key's algorithm to the JWS signing algorithm used to sign the
+ * rewrap request token. RSA keys sign with RS256; EC keys sign with the ECDSA
+ * algorithm matching their curve.
+ */
+function signingAlgForKeyAlgorithm(algorithm: KeyAlgorithm): AsymmetricSigningAlgorithm {
+  switch (algorithm) {
+    case 'rsa:2048':
+    case 'rsa:4096':
+      return 'RS256';
+    case 'ec:secp256r1':
+      return 'ES256';
+    case 'ec:secp384r1':
+      return 'ES384';
+    case 'ec:secp521r1':
+      return 'ES512';
+    default:
+      throw new ConfigurationError(`Unsupported signing key algorithm [${algorithm}]`);
+  }
+}
+
 async function unwrapKey({
   manifest,
   allowedKases,
@@ -855,7 +878,12 @@ async function unwrapKey({
     const requestBodyStr = toJsonString(UnsignedRewrapRequestSchema, unsignedRequest);
 
     const jwtPayload = { requestBody: requestBodyStr };
-    const signedRequestToken = await reqSignature(jwtPayload, dpopKeys.privateKey, cryptoService);
+    // The request token must be signed with the algorithm matching the dpop key
+    // type. Defaulting to RS256 breaks EC keys (e.g. DPoP ES256), since WebCrypto
+    // rejects signing an EC key with RSA params ("Unable to use this key to sign").
+    const signedRequestToken = await reqSignature(jwtPayload, dpopKeys.privateKey, cryptoService, {
+      alg: signingAlgForKeyAlgorithm(dpopKeys.privateKey.algorithm),
+    });
 
     const rewrapResp = await fetchWrappedKey(
       url,

--- a/lib/tests/mocha/dpop-proof.spec.ts
+++ b/lib/tests/mocha/dpop-proof.spec.ts
@@ -1,0 +1,184 @@
+import { expect } from 'chai';
+import * as jose from 'jose';
+
+import dpopFn from '../../src/auth/dpop.js';
+import { DefaultCryptoService } from '../../tdf3/src/crypto/index.js';
+import type { KeyPair } from '../../tdf3/src/crypto/declarations.js';
+import { CURVES, ecdsaKeyPair, rsaKeyPair } from './helpers/jws-keys.js';
+
+/**
+ * End-to-end DPoP proof signing tests.
+ *
+ * These tests verify the proofs minted by `dpopFn` (the function called from
+ * `AccessToken.doPost` and `withCreds`) against an independent, RFC 9449 /
+ * RFC 7518 §3.4 conformant verifier (`jose.jwtVerify`).
+ *
+ * Why these tests exist: the SDK's internal sign/verify pair is symmetric
+ * (both encode/decode ECDSA signatures as DER), so it round-trips inside this
+ * SDK even when the wire format is non-conformant. `jose.jwtVerify` is the
+ * same library used by real Keycloak under the hood — feeding our proofs
+ * through it catches DER-vs-raw and similar bugs that the in-SDK round-trip
+ * cannot. The earlier DSPX-3397 "Invalid token signature" failure from
+ * Keycloak would have been caught locally by these tests.
+ */
+
+const HTU = 'https://example.test/protocol/openid-connect/token';
+const HTM = 'POST';
+
+describe('DPoP proof — JWS conformance vs jose.jwtVerify (RFC 9449 + RFC 7518 §3.4)', function (this: Mocha.Suite) {
+  this.timeout(10_000);
+
+  for (const { namedCurve, alg } of CURVES) {
+    it(`${alg} proof verifies against jose.jwtVerify`, async () => {
+      const { sdk: kp } = await ecdsaKeyPair(namedCurve);
+      const proof = await dpopFn(kp, DefaultCryptoService, HTU, HTM);
+
+      // Verify with the public key extracted from the proof's own header, the
+      // way a real DPoP-aware server (Keycloak) would.
+      const header = jose.decodeProtectedHeader(proof);
+      expect(header.typ).to.equal('dpop+jwt');
+      expect(header.alg).to.equal(alg);
+      expect(header.jwk).to.exist;
+
+      const key = await jose.importJWK(header.jwk as jose.JWK, alg);
+      const { payload } = await jose.jwtVerify(proof, key);
+      expect(payload.htu).to.equal(HTU);
+      expect(payload.htm).to.equal(HTM);
+      expect(payload.jti).to.be.a('string').and.have.length.greaterThan(0);
+      expect(payload.iat).to.be.a('number');
+    });
+
+    it(`${alg} proof verification rejects a flipped signature byte`, async () => {
+      const { sdk: kp } = await ecdsaKeyPair(namedCurve);
+      const proof = await dpopFn(kp, DefaultCryptoService, HTU, HTM);
+      const tampered = flipOneBitInSignatureSegment(proof);
+
+      const header = jose.decodeProtectedHeader(proof);
+      const key = await jose.importJWK(header.jwk as jose.JWK, alg);
+      let threw = false;
+      try {
+        await jose.jwtVerify(tampered, key);
+      } catch {
+        threw = true;
+      }
+      expect(threw, 'jose.jwtVerify must reject a tampered signature').to.equal(true);
+    });
+
+    it(`${alg} proof verification rejects a swapped jwk header (binding intact, key wrong)`, async () => {
+      const { sdk: kp1 } = await ecdsaKeyPair(namedCurve);
+      const { sdk: kp2 } = await ecdsaKeyPair(namedCurve);
+
+      const proof = await dpopFn(kp1, DefaultCryptoService, HTU, HTM);
+
+      // Build a forged proof: same payload + signature but kp2's public JWK in
+      // the header. A correct verifier must reject because the signature was
+      // made by kp1.privateKey.
+      const [hdrB64, payloadB64, sigB64] = proof.split('.');
+      const realHeader = JSON.parse(
+        new TextDecoder().decode(jose.base64url.decode(hdrB64))
+      ) as jose.ProtectedHeaderParameters;
+      const fakeJwk = await crypto.subtle.exportKey(
+        'jwk',
+        (await jose.importJWK((await proofHeaderJwkFor(kp2, alg)) as jose.JWK, alg)) as CryptoKey
+      );
+      delete (fakeJwk as Record<string, unknown>).d;
+      delete (fakeJwk as Record<string, unknown>).key_ops;
+      realHeader.jwk = fakeJwk as jose.JWK;
+      const forgedHdrB64 = jose.base64url.encode(
+        new TextEncoder().encode(JSON.stringify(realHeader))
+      );
+      const forged = `${forgedHdrB64}.${payloadB64}.${sigB64}`;
+
+      const key = await jose.importJWK(realHeader.jwk as jose.JWK, alg);
+      let threw = false;
+      try {
+        await jose.jwtVerify(forged, key);
+      } catch {
+        threw = true;
+      }
+      expect(threw, 'jose.jwtVerify must reject a forged proof with mismatched jwk').to.equal(true);
+    });
+  }
+});
+
+describe('DPoP proof — RS256 JWS conformance vs jose.jwtVerify (RFC 9449)', function (this: Mocha.Suite) {
+  this.timeout(10_000);
+
+  it('RS256 proof verifies against jose.jwtVerify', async () => {
+    const { sdk: kp } = await rsaKeyPair();
+    const proof = await dpopFn(kp, DefaultCryptoService, HTU, HTM);
+
+    const header = jose.decodeProtectedHeader(proof);
+    expect(header.typ).to.equal('dpop+jwt');
+    expect(header.alg).to.equal('RS256');
+    expect(header.jwk).to.exist;
+
+    const key = await jose.importJWK(header.jwk as jose.JWK, 'RS256');
+    const { payload } = await jose.jwtVerify(proof, key);
+    expect(payload.htu).to.equal(HTU);
+    expect(payload.htm).to.equal(HTM);
+    expect(payload.jti).to.be.a('string').and.have.length.greaterThan(0);
+    expect(payload.iat).to.be.a('number');
+  });
+
+  it('RS256 proof verification rejects a flipped signature byte', async () => {
+    const { sdk: kp } = await rsaKeyPair();
+    const proof = await dpopFn(kp, DefaultCryptoService, HTU, HTM);
+    const tampered = flipOneBitInSignatureSegment(proof);
+
+    const header = jose.decodeProtectedHeader(proof);
+    const key = await jose.importJWK(header.jwk as jose.JWK, 'RS256');
+    let threw = false;
+    try {
+      await jose.jwtVerify(tampered, key);
+    } catch {
+      threw = true;
+    }
+    expect(threw, 'jose.jwtVerify must reject a tampered RS256 signature').to.equal(true);
+  });
+});
+
+describe('DPoP proof — unsupported key algorithm', function () {
+  it('throws before signing when the key algorithm is not a supported JWS alg', async () => {
+    // determineJWSAlgorithmFromKeyInfo (now typed to return only the four
+    // AsymmetricSigningAlgorithm values) must still reject an unknown key
+    // algorithm string up front, rather than the type change silently widening
+    // what flows into the signer.
+    const bogusKeyPair = {
+      publicKey: { algorithm: 'ec:brainpoolP256r1' },
+      privateKey: {},
+    } as unknown as KeyPair;
+
+    let err: Error | undefined;
+    try {
+      await dpopFn(bogusKeyPair, DefaultCryptoService, HTU, HTM);
+    } catch (e) {
+      err = e as Error;
+    }
+    expect(err, 'expected an unsupported-algorithm error').to.be.instanceOf(Error);
+    expect(err?.message).to.match(/unsupported key algorithm/);
+  });
+});
+
+/**
+ * Mint a real proof solely to extract a clean JWK for the public key.
+ * Round-tripping through `dpopFn` ensures the JWK shape matches what the
+ * SDK emits in real proofs.
+ */
+async function proofHeaderJwkFor(kp: KeyPair, alg: 'ES256' | 'ES384' | 'ES512'): Promise<unknown> {
+  const proof = await dpopFn(kp, DefaultCryptoService, HTU, HTM);
+  const header = jose.decodeProtectedHeader(proof);
+  void alg; // alg unused; kept in signature for caller clarity
+  return header.jwk;
+}
+
+/**
+ * Flip exactly one bit of the base64url-decoded signature segment.
+ * Re-encodes back into the JWT compact form.
+ */
+function flipOneBitInSignatureSegment(jwt: string): string {
+  const [h, p, s] = jwt.split('.');
+  const sig = jose.base64url.decode(s);
+  sig[0] ^= 0x01;
+  return `${h}.${p}.${jose.base64url.encode(sig)}`;
+}

--- a/lib/tests/mocha/encrypt-decrypt.spec.ts
+++ b/lib/tests/mocha/encrypt-decrypt.spec.ts
@@ -420,6 +420,53 @@ describe('encrypt decrypt test', async function () {
     assert.equal(new TextDecoder().decode(decryptedText), expectedVal);
   });
 
+  it('decrypt signs the rewrap request token with EC dpop keys (ES256)', async function () {
+    // Regression for DSPX-3397: the rewrap request token was always signed with
+    // RS256, which made WebCrypto reject EC dpop keys ("Unable to use this key to
+    // sign"). The token alg must follow the dpop key algorithm.
+    const cipher = new AesGcmCipher(WebCryptoService);
+    const encryptionInformation = new SplitKey(cipher);
+    const key1 = await encryptionInformation.generateKey();
+    const keyMiddleware = async () => ({ keyForEncryption: key1, keyForManifest: key1 });
+
+    const client = new Client.Client({
+      kasEndpoint: kasUrl,
+      platformUrl: kasUrl,
+      dpopKeys: Mocks.entityECKeyPair(),
+      clientId: 'id',
+      authProvider,
+    });
+
+    const scope: Scope = {
+      dissem: ['user@domain.com'],
+      attributes: [],
+    };
+
+    const encryptedStream = await client.encrypt({
+      metadata: Mocks.getMetadataObject(),
+      wrappingKeyAlgorithm: 'rsa:2048',
+      offline: true,
+      scope,
+      keyMiddleware,
+      source: new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode(expectedVal));
+          controller.close();
+        },
+      }),
+    });
+
+    const decryptStream = await client.decrypt({
+      source: {
+        type: 'stream',
+        location: encryptedStream.stream,
+      },
+    });
+
+    const { value: decryptedText } = await decryptStream.stream.getReader().read();
+    assert.equal(new TextDecoder().decode(decryptedText), expectedVal);
+  });
+
   it('encrypt-decrypt with system metadata assertion', async function () {
     const cipher = new AesGcmCipher(WebCryptoService);
     const encryptionInformation = new SplitKey(cipher);

--- a/lib/tests/mocha/helpers/jws-keys.ts
+++ b/lib/tests/mocha/helpers/jws-keys.ts
@@ -1,71 +1,54 @@
-import { importPrivateKey, importPublicKey } from '../../../tdf3/src/crypto/core/key-format.js';
-import type { KeyPair } from '../../../tdf3/src/crypto/declarations.js';
+import { exportPublicKeyPem } from '../../../tdf3/src/crypto/core/key-format.js';
+import { wrapPrivateKey, wrapPublicKey } from '../../../tdf3/src/crypto/core/keys.js';
+import { generateSigningKeyPair } from '../../../tdf3/src/crypto/core/rsa.js';
+import type {
+  ECCurve,
+  EcKeyAlgorithm,
+  EcSigningAlgorithm,
+  KeyPair,
+} from '../../../tdf3/src/crypto/declarations.js';
 
 /**
- * Shared key fixtures for the JWS conformance suites (dpop-proof, reqsignature-jws).
+ * Shared signing-key fixtures for the JWS suites (dpop-proof, reqsignature-jws,
+ * assertions).
  *
- * Both suites need SDK-opaque KeyPairs generated the way real callers get them:
- * raw WebCrypto keygen, exported to DER, wrapped as PEM, then imported through
- * the SDK's key-format layer (the same dance `cli/src/dpop-helpers.ts` does).
- * The PEM is returned alongside so tests can hand it to `jose.importSPKI` for
- * independent verification.
+ * Each fixture returns an SDK-opaque `KeyPair` alongside its SPKI PEM, so tests
+ * can hand the PEM to `jose.importSPKI` and verify the SDK's output with an
+ * independent, RFC-conformant implementation.
  */
 
-export type NamedCurve = 'P-256' | 'P-384' | 'P-521';
-export type EcdsaAlg = 'ES256' | 'ES384' | 'ES512';
-
-export const CURVES: Array<{ namedCurve: NamedCurve; alg: EcdsaAlg }> = [
+export const CURVES: Array<{ namedCurve: ECCurve; alg: EcSigningAlgorithm }> = [
   { namedCurve: 'P-256', alg: 'ES256' },
   { namedCurve: 'P-384', alg: 'ES384' },
   { namedCurve: 'P-521', alg: 'ES512' },
 ];
 
-export type PemKeyPair = { sdk: KeyPair; pubPem: string };
+export type TestKeyPair = { sdk: KeyPair; pubPem: string };
 
-export function derToPem(der: Uint8Array, label: string): string {
-  let b = '';
-  for (let i = 0; i < der.length; i++) b += String.fromCharCode(der[i]);
-  const b64 =
-    btoa(b)
-      .match(/.{1,64}/g)
-      ?.join('\n') ?? btoa(b);
-  return `-----BEGIN ${label}-----\n${b64}\n-----END ${label}-----`;
+const CURVE_ALGORITHMS: Record<ECCurve, EcKeyAlgorithm> = {
+  'P-256': 'ec:secp256r1',
+  'P-384': 'ec:secp384r1',
+  'P-521': 'ec:secp521r1',
+};
+
+async function withPem(sdk: KeyPair): Promise<TestKeyPair> {
+  return { sdk, pubPem: await exportPublicKeyPem(sdk.publicKey) };
 }
 
-export function decodeBase64url(value: string): Uint8Array {
-  const base64 = value
-    .replace(/-/g, '+')
-    .replace(/_/g, '/')
-    .padEnd(Math.ceil(value.length / 4) * 4, '=');
-  return Uint8Array.from(atob(base64), (character) => character.charCodeAt(0));
-}
-
-export function encodeBase64url(value: Uint8Array): string {
-  let binary = '';
-  for (const byte of value) binary += String.fromCharCode(byte);
-  return btoa(binary).replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_');
-}
-
-async function toSdkKeyPair(raw: CryptoKeyPair): Promise<PemKeyPair> {
-  const [privDer, pubDer] = await Promise.all([
-    crypto.subtle.exportKey('pkcs8', raw.privateKey),
-    crypto.subtle.exportKey('spki', raw.publicKey),
-  ]);
-  const privPem = derToPem(new Uint8Array(privDer), 'PRIVATE KEY');
-  const pubPem = derToPem(new Uint8Array(pubDer), 'PUBLIC KEY');
-  const [privateKey, publicKey] = await Promise.all([
-    importPrivateKey(privPem, { usage: 'sign', extractable: true }),
-    importPublicKey(pubPem, { usage: 'sign', extractable: true }),
-  ]);
-  return { sdk: { publicKey, privateKey }, pubPem };
-}
-
-export async function ecdsaKeyPair(namedCurve: NamedCurve): Promise<PemKeyPair> {
+/**
+ * Generated with raw WebCrypto rather than `generateECKeyPair`, which produces
+ * ECDH `deriveBits` keys that cannot sign.
+ */
+export async function ecdsaKeyPair(namedCurve: ECCurve): Promise<TestKeyPair> {
+  const algorithm = CURVE_ALGORITHMS[namedCurve];
   const raw = await crypto.subtle.generateKey({ name: 'ECDSA', namedCurve }, true, [
     'sign',
     'verify',
   ]);
-  return toSdkKeyPair(raw);
+  return withPem({
+    publicKey: wrapPublicKey(raw.publicKey, algorithm),
+    privateKey: wrapPrivateKey(raw.privateKey, algorithm),
+  });
 }
 
 /**
@@ -73,16 +56,6 @@ export async function ecdsaKeyPair(namedCurve: NamedCurve): Promise<PemKeyPair> 
  * is passed through unconverted (no DER<->P1363 transform). Suites use this to
  * exercise that pass-through branch against the same conformant verifier.
  */
-export async function rsaKeyPair(): Promise<PemKeyPair> {
-  const raw = await crypto.subtle.generateKey(
-    {
-      name: 'RSASSA-PKCS1-v1_5',
-      modulusLength: 2048,
-      publicExponent: new Uint8Array([1, 0, 1]),
-      hash: 'SHA-256',
-    },
-    true,
-    ['sign', 'verify']
-  );
-  return toSdkKeyPair(raw);
+export async function rsaKeyPair(): Promise<TestKeyPair> {
+  return withPem(await generateSigningKeyPair());
 }

--- a/lib/tests/mocha/helpers/jws-keys.ts
+++ b/lib/tests/mocha/helpers/jws-keys.ts
@@ -1,0 +1,88 @@
+import { importPrivateKey, importPublicKey } from '../../../tdf3/src/crypto/core/key-format.js';
+import type { KeyPair } from '../../../tdf3/src/crypto/declarations.js';
+
+/**
+ * Shared key fixtures for the JWS conformance suites (dpop-proof, reqsignature-jws).
+ *
+ * Both suites need SDK-opaque KeyPairs generated the way real callers get them:
+ * raw WebCrypto keygen, exported to DER, wrapped as PEM, then imported through
+ * the SDK's key-format layer (the same dance `cli/src/dpop-helpers.ts` does).
+ * The PEM is returned alongside so tests can hand it to `jose.importSPKI` for
+ * independent verification.
+ */
+
+export type NamedCurve = 'P-256' | 'P-384' | 'P-521';
+export type EcdsaAlg = 'ES256' | 'ES384' | 'ES512';
+
+export const CURVES: Array<{ namedCurve: NamedCurve; alg: EcdsaAlg }> = [
+  { namedCurve: 'P-256', alg: 'ES256' },
+  { namedCurve: 'P-384', alg: 'ES384' },
+  { namedCurve: 'P-521', alg: 'ES512' },
+];
+
+export type PemKeyPair = { sdk: KeyPair; pubPem: string };
+
+export function derToPem(der: Uint8Array, label: string): string {
+  let b = '';
+  for (let i = 0; i < der.length; i++) b += String.fromCharCode(der[i]);
+  const b64 =
+    btoa(b)
+      .match(/.{1,64}/g)
+      ?.join('\n') ?? btoa(b);
+  return `-----BEGIN ${label}-----\n${b64}\n-----END ${label}-----`;
+}
+
+export function decodeBase64url(value: string): Uint8Array {
+  const base64 = value
+    .replace(/-/g, '+')
+    .replace(/_/g, '/')
+    .padEnd(Math.ceil(value.length / 4) * 4, '=');
+  return Uint8Array.from(atob(base64), (character) => character.charCodeAt(0));
+}
+
+export function encodeBase64url(value: Uint8Array): string {
+  let binary = '';
+  for (const byte of value) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_');
+}
+
+async function toSdkKeyPair(raw: CryptoKeyPair): Promise<PemKeyPair> {
+  const [privDer, pubDer] = await Promise.all([
+    crypto.subtle.exportKey('pkcs8', raw.privateKey),
+    crypto.subtle.exportKey('spki', raw.publicKey),
+  ]);
+  const privPem = derToPem(new Uint8Array(privDer), 'PRIVATE KEY');
+  const pubPem = derToPem(new Uint8Array(pubDer), 'PUBLIC KEY');
+  const [privateKey, publicKey] = await Promise.all([
+    importPrivateKey(privPem, { usage: 'sign', extractable: true }),
+    importPublicKey(pubPem, { usage: 'sign', extractable: true }),
+  ]);
+  return { sdk: { publicKey, privateKey }, pubPem };
+}
+
+export async function ecdsaKeyPair(namedCurve: NamedCurve): Promise<PemKeyPair> {
+  const raw = await crypto.subtle.generateKey({ name: 'ECDSA', namedCurve }, true, [
+    'sign',
+    'verify',
+  ]);
+  return toSdkKeyPair(raw);
+}
+
+/**
+ * RS256 is the default DPoP alg for any RSA key and, unlike ES*, its signature
+ * is passed through unconverted (no DER<->P1363 transform). Suites use this to
+ * exercise that pass-through branch against the same conformant verifier.
+ */
+export async function rsaKeyPair(): Promise<PemKeyPair> {
+  const raw = await crypto.subtle.generateKey(
+    {
+      name: 'RSASSA-PKCS1-v1_5',
+      modulusLength: 2048,
+      publicExponent: new Uint8Array([1, 0, 1]),
+      hash: 'SHA-256',
+    },
+    true,
+    ['sign', 'verify']
+  );
+  return toSdkKeyPair(raw);
+}

--- a/lib/tests/mocha/reqsignature-jws.spec.ts
+++ b/lib/tests/mocha/reqsignature-jws.spec.ts
@@ -1,0 +1,84 @@
+import { expect } from 'chai';
+import * as jose from 'jose';
+
+import { reqSignature } from '../../src/auth/auth.js';
+import { signJwt, verifyJwt } from '../../tdf3/src/crypto/jwt.js';
+import { DefaultCryptoService } from '../../tdf3/src/crypto/index.js';
+import { CURVES, ecdsaKeyPair, rsaKeyPair } from './helpers/jws-keys.js';
+
+/**
+ * RFC 7518 §3.4 conformance for `signJwt`/`reqSignature` (the KAS rewrap request
+ * token signer).
+ *
+ * Regression for DSPX-3397: the rewrap request token was signed with ECDSA
+ * signatures in DER form, which a real (RFC-conformant) KAS rejects with
+ * "unable to verify request token". The mock test server only `decodeJwt`s the
+ * token (no signature check), so the in-SDK round-trip and the mock both passed
+ * while the real platform failed. Verifying against `jose.jwtVerify` — which
+ * requires raw IEEE P1363 (R||S) signatures — catches the DER-vs-raw bug.
+ */
+
+describe('reqSignature / signJwt — JWS conformance vs jose.jwtVerify (RFC 7518 §3.4)', function (this: Mocha.Suite) {
+  this.timeout(10_000);
+
+  for (const { namedCurve, alg } of CURVES) {
+    it(`reqSignature ${alg} token verifies against jose.jwtVerify`, async () => {
+      const { sdk, pubPem } = await ecdsaKeyPair(namedCurve);
+
+      const token = await reqSignature(
+        { requestBody: 'hello' },
+        sdk.privateKey,
+        DefaultCryptoService,
+        {
+          alg,
+        }
+      );
+
+      // jose requires raw IEEE P1363 signatures — this rejects DER.
+      const key = await jose.importSPKI(pubPem, alg);
+      const { payload } = await jose.jwtVerify(token, key);
+      expect(payload.requestBody).to.equal('hello');
+      expect(payload.iat).to.be.a('number');
+      expect(payload.exp).to.be.a('number');
+    });
+
+    it(`signJwt ${alg} round-trips through verifyJwt`, async () => {
+      const { sdk } = await ecdsaKeyPair(namedCurve);
+      const token = await signJwt(DefaultCryptoService, { sub: 'test' }, sdk.privateKey, { alg });
+      const { payload } = await verifyJwt(DefaultCryptoService, token, sdk.publicKey, {
+        algorithms: [alg],
+      });
+      expect(payload.sub).to.equal('test');
+    });
+  }
+
+  it('reqSignature RS256 token verifies against jose.jwtVerify', async () => {
+    const { sdk, pubPem } = await rsaKeyPair();
+
+    const token = await reqSignature(
+      { requestBody: 'hello' },
+      sdk.privateKey,
+      DefaultCryptoService,
+      {
+        alg: 'RS256',
+      }
+    );
+
+    const key = await jose.importSPKI(pubPem, 'RS256');
+    const { payload } = await jose.jwtVerify(token, key);
+    expect(payload.requestBody).to.equal('hello');
+    expect(payload.iat).to.be.a('number');
+    expect(payload.exp).to.be.a('number');
+  });
+
+  it('signJwt RS256 round-trips through verifyJwt', async () => {
+    const { sdk } = await rsaKeyPair();
+    const token = await signJwt(DefaultCryptoService, { sub: 'test' }, sdk.privateKey, {
+      alg: 'RS256',
+    });
+    const { payload } = await verifyJwt(DefaultCryptoService, token, sdk.publicKey, {
+      algorithms: ['RS256'],
+    });
+    expect(payload.sub).to.equal('test');
+  });
+});

--- a/lib/tests/mocha/unit/assertions.spec.ts
+++ b/lib/tests/mocha/unit/assertions.spec.ts
@@ -1,13 +1,15 @@
 // tests for assertions.ts
 
 import { expect } from 'chai';
+import { base64url } from 'jose';
 
 import * as assertions from '../../../tdf3/src/assertions.js';
 import * as DefaultCryptoService from '../../../tdf3/src/crypto/index.js';
 import { hex, base64 } from '../../../src/encodings/index.js';
+import { exportPublicKeyJwk } from '../../../tdf3/src/crypto/core/key-format.js';
 import { signJwt } from '../../../tdf3/src/crypto/jwt.js';
 import type { CryptoService } from '../../../tdf3/src/crypto/declarations.js';
-import { decodeBase64url } from '../helpers/jws-keys.js';
+import { ecdsaKeyPair } from '../helpers/jws-keys.js';
 
 describe('assertions', () => {
   const cryptoService: CryptoService = DefaultCryptoService;
@@ -64,28 +66,10 @@ describe('assertions', () => {
     const isLegacyTDF = false;
 
     it('should verify assertion using jwk from header', async () => {
-      // Generate ECDSA key pair for ES256 signing (not ECDH)
-      const webCryptoKeyPair = await crypto.subtle.generateKey(
-        { name: 'ECDSA', namedCurve: 'P-256' },
-        true,
-        ['sign', 'verify']
-      );
-      const keyPair = {
-        publicKey: {
-          _brand: 'PublicKey',
-          algorithm: 'ec:secp256r1',
-          curve: 'P-256',
-          _internal: webCryptoKeyPair.publicKey,
-        } as any,
-        privateKey: {
-          _brand: 'PrivateKey',
-          algorithm: 'ec:secp256r1',
-          curve: 'P-256',
-          _internal: webCryptoKeyPair.privateKey,
-        } as any,
-      };
+      // ES256 signing key pair (ECDSA, not ECDH)
+      const { sdk: keyPair } = await ecdsaKeyPair('P-256');
       // Get JWK from the public key
-      const jwk = await crypto.subtle.exportKey('jwk', webCryptoKeyPair.publicKey);
+      const jwk = await exportPublicKeyJwk(keyPair.publicKey);
 
       const assertion: assertions.Assertion = {
         id: 'test-assertion',
@@ -137,19 +121,10 @@ describe('assertions', () => {
       // 7518 §3.4 requires raw R || S (64 bytes for P-256); ASN.1 DER is 69-72
       // bytes and is rejected on length by conformant verifiers. Pin the width
       // so no encoding change can slip into the file format unnoticed.
-      const webCryptoKeyPair = await crypto.subtle.generateKey(
-        { name: 'ECDSA', namedCurve: 'P-256' },
-        true,
-        ['sign', 'verify']
-      );
+      const { sdk: keyPair } = await ecdsaKeyPair('P-256');
       const signingKey: assertions.AssertionKey = {
         alg: 'ES256',
-        key: {
-          _brand: 'PrivateKey',
-          algorithm: 'ec:secp256r1',
-          curve: 'P-256',
-          _internal: webCryptoKeyPair.privateKey,
-        } as any,
+        key: keyPair.privateKey,
       };
 
       const assertion = await assertions.CreateAssertion(
@@ -170,19 +145,14 @@ describe('assertions', () => {
       );
 
       const [, , signatureB64url] = assertion.binding.signature.split('.');
-      expect(decodeBase64url(signatureB64url).length).to.equal(64);
+      expect(base64url.decode(signatureB64url).length).to.equal(64);
 
       await assertions.verify(
         assertion,
         aggregateHash,
         {
           alg: 'ES256',
-          key: {
-            _brand: 'PublicKey',
-            algorithm: 'ec:secp256r1',
-            curve: 'P-256',
-            _internal: webCryptoKeyPair.publicKey,
-          } as any,
+          key: keyPair.publicKey,
         },
         isLegacyTDF,
         cryptoService

--- a/lib/tests/mocha/unit/assertions.spec.ts
+++ b/lib/tests/mocha/unit/assertions.spec.ts
@@ -7,6 +7,7 @@ import * as DefaultCryptoService from '../../../tdf3/src/crypto/index.js';
 import { hex, base64 } from '../../../src/encodings/index.js';
 import { signJwt } from '../../../tdf3/src/crypto/jwt.js';
 import type { CryptoService } from '../../../tdf3/src/crypto/declarations.js';
+import { decodeBase64url } from '../helpers/jws-keys.js';
 
 describe('assertions', () => {
   const cryptoService: CryptoService = DefaultCryptoService;
@@ -128,6 +129,64 @@ describe('assertions', () => {
       };
 
       await assertions.verify(assertion, aggregateHash, dummyKey, isLegacyTDF, cryptoService);
+    });
+
+    it('persists ES256 bindings as raw IEEE P1363, the only encoding on the wire', async () => {
+      // binding.signature is the one signature this SDK writes to durable
+      // storage — it lands in the manifest and is read back by other SDKs. RFC
+      // 7518 §3.4 requires raw R || S (64 bytes for P-256); ASN.1 DER is 69-72
+      // bytes and is rejected on length by conformant verifiers. Pin the width
+      // so no encoding change can slip into the file format unnoticed.
+      const webCryptoKeyPair = await crypto.subtle.generateKey(
+        { name: 'ECDSA', namedCurve: 'P-256' },
+        true,
+        ['sign', 'verify']
+      );
+      const signingKey: assertions.AssertionKey = {
+        alg: 'ES256',
+        key: {
+          _brand: 'PrivateKey',
+          algorithm: 'ec:secp256r1',
+          curve: 'P-256',
+          _internal: webCryptoKeyPair.privateKey,
+        } as any,
+      };
+
+      const assertion = await assertions.CreateAssertion(
+        aggregateHash,
+        {
+          id: 'raw-p1363-binding',
+          type: 'handling',
+          scope: 'tdo',
+          appliesToState: 'unencrypted',
+          statement: {
+            format: 'json',
+            schema: 'test-schema',
+            value: '{"foo":"bar"}',
+          },
+          signingKey,
+        },
+        cryptoService
+      );
+
+      const [, , signatureB64url] = assertion.binding.signature.split('.');
+      expect(decodeBase64url(signatureB64url).length).to.equal(64);
+
+      await assertions.verify(
+        assertion,
+        aggregateHash,
+        {
+          alg: 'ES256',
+          key: {
+            _brand: 'PublicKey',
+            algorithm: 'ec:secp256r1',
+            curve: 'P-256',
+            _internal: webCryptoKeyPair.publicKey,
+          } as any,
+        },
+        isLegacyTDF,
+        cryptoService
+      );
     });
 
     it('should fallback to provided key if no key in header', async () => {

--- a/lib/tests/mocha/unit/crypto/crypto-service.spec.ts
+++ b/lib/tests/mocha/unit/crypto/crypto-service.spec.ts
@@ -557,42 +557,41 @@ describe('Crypto Service', () => {
       expect(valid).to.be.true;
     });
 
-    it('ES512 DER output is well-formed and round-trips correctly', async () => {
-      // Verifies that ieeeP1363ToDer and derToIeeeP1363 both use correct DER length
-      // encoding, including long-form (0x81 <len>) when the SEQUENCE body is ≥ 128 bytes.
-      // Correct encoding is required for interoperability with external parsers
-      // (Go crypto, OpenSSL, etc.) that strictly validate the DER structure.
-      const webCryptoKeyPair = await crypto.subtle.generateKey(
-        { name: 'ECDSA', namedCurve: 'P-521' },
-        true,
-        ['sign', 'verify']
-      );
-      const ecKeyPair = {
-        publicKey: {
-          _brand: 'PublicKey',
-          algorithm: 'ec:secp521r1',
-          curve: 'P-521',
-          _internal: webCryptoKeyPair.publicKey,
-        } as any,
-        privateKey: {
+    // RFC 7518 §3.4 fixes the ECDSA signature encoding for JWS as raw IEEE
+    // P1363 (R || S), one fixed-width field element each. ASN.1 DER — which is
+    // what several non-WebCrypto stacks emit — is variable length and always
+    // longer, so an exact byte count is what distinguishes the two. Signatures
+    // go from here straight onto the wire, so a regression here silently
+    // produces tokens that conformant verifiers (jose, jwx, nimbus) reject.
+    const RAW_SIGNATURE_BYTES = [
+      { alg: 'ES256', namedCurve: 'P-256', keyAlgorithm: 'ec:secp256r1', length: 64 },
+      { alg: 'ES384', namedCurve: 'P-384', keyAlgorithm: 'ec:secp384r1', length: 96 },
+      { alg: 'ES512', namedCurve: 'P-521', keyAlgorithm: 'ec:secp521r1', length: 132 },
+    ] as const;
+
+    for (const { alg, namedCurve, keyAlgorithm, length } of RAW_SIGNATURE_BYTES) {
+      it(`${alg} signatures are exactly ${length} raw bytes, never DER`, async () => {
+        const webCryptoKeyPair = await crypto.subtle.generateKey(
+          { name: 'ECDSA', namedCurve },
+          true,
+          ['sign', 'verify']
+        );
+        const privateKey = {
           _brand: 'PrivateKey',
-          algorithm: 'ec:secp521r1',
-          curve: 'P-521',
+          algorithm: keyAlgorithm,
+          curve: namedCurve,
           _internal: webCryptoKeyPair.privateKey,
-        } as any,
-      };
-      const data = new TextEncoder().encode('test data for ES512 DER long-form');
+        } as any;
+        const data = new TextEncoder().encode(`raw signature width check for ${alg}`);
 
-      const der = await sign(data, ecKeyPair.privateKey, 'ES512');
-
-      // Output must be a DER SEQUENCE regardless of component size.
-      expect(der[0]).to.equal(0x30);
-
-      // Round-trip validates that the length field was encoded and decoded consistently,
-      // including long-form (needed when the SEQUENCE body is ≥ 128 bytes).
-      const valid = await verify(data, der, ecKeyPair.publicKey, 'ES512');
-      expect(valid).to.be.true;
-    });
+        // A handful of draws: r and s are uniform, so ~1 signature in 256 has a
+        // leading zero byte that DER would drop and P1363 must keep.
+        for (let i = 0; i < 8; i++) {
+          const signature = await sign(data, privateKey, alg);
+          expect(signature.length).to.equal(length);
+        }
+      });
+    }
   });
 
   describe('sign and verify with RS256', () => {


### PR DESCRIPTION
Stack 1/6, split out of #939. Base: `main`.

## What

`cryptoService.sign()` returned DER-encoded ECDSA signatures, but JWS requires raw IEEE P1363 (`R || S`) per [RFC 7518 §3.4](https://www.rfc-editor.org/rfc/rfc7518#section-3.4). Every JWS emitter was shipping DER:

- `tdf3/src/crypto/jwt.ts` — the KAS rewrap request token, and the assertion binding
- `src/auth/dpop.ts` — the DPoP proof

so any EC-keyed token was rejected by conformant verifiers. This is the "Invalid token signature" / "unable to verify request token" failure seen against Keycloak. `verifyJwt` had the mirror bug: it fed a raw JWS signature to a verifier that expects DER.

Separately, `reqSignature` defaulted to `RS256` for the rewrap request token. WebCrypto rejects signing an EC private key with RSA params (`Unable to use this key to sign`), so an EC dpop key could not produce a rewrap token at all. The alg is now derived from the key's algorithm.

## Why it wasn't caught

The SDK's own sign/verify pair was symmetric — both sides spoke DER — so it round-tripped internally even when the wire format was wrong. The mock test server only `decodeJwt`s the rewrap token and never checks the signature. Both passed while the real platform failed.

The new tests verify against `jose.jwtVerify`, an independent RFC-conformant verifier (the same library Keycloak uses), which is what closes that gap.

## Approach: remove DER, don't transcode

An earlier revision of this PR converted DER→raw at each call site, leaving `sign()` emitting DER and every caller immediately undoing it. That round-trip is gone: **`sign()` returns raw IEEE P1363 for `ES*` and `verify()` takes raw**, so the bytes go from WebCrypto straight to the wire unchanged. There is no ASN.1 DER code left in the SDK.

No compatibility shim is included, deliberately:

- **Nothing in the wild reads the old format.** The one persistent signature this SDK writes is the assertion `binding.signature`; the DPoP proof and rewrap token are ephemeral. Producing an EC-signed assertion requires hand-constructing an `AssertionKey` — the CLI has no flag for it and `AssertionKeyAlg` is `ES256 | RS256 | HS256` with no EC key generation path — and a GitHub-wide search found no callers.
- **The Go and Java SDKs can't read EC assertions at all**, in either encoding, so there is no cross-SDK legacy corpus.
- **Third-party `CryptoService` plugins already speak raw.** The virtru FIPS implementation (`libraries/fips-web-crypto`) emits `size*2` fixed-width bytes and its verifier *hard-rejects* anything else (`"ECDSA signature must be %d bytes"`). A DER-tolerant design would have broken it.

This supersedes DSPX-3634 (formerly stack 8/8, #996), which is now closed as subsumed.

## Changes

- `tdf3/src/crypto/core/signing.ts`: delete `ieeeP1363ToDer` / `derToIeeeP1363` and the per-curve component-width table; `sign()`/`verify()` now pass WebCrypto's bytes through
- `tdf3/src/crypto/jwt.ts`, `src/auth/dpop.ts`: no conversion at the call sites
- `tdf3/src/tdf.ts`: `signingAlgForKeyAlgorithm()` picks the rewrap token alg from the dpop key
- `tdf3/src/crypto/declarations.ts`: derive `AsymmetricSigningAlgorithm` from a runtime `as const` list so the type and the guard can't drift; add `isAsymmetricSigningAlgorithm()` so the JWS `alg` header is validated rather than blind-cast (the JWS alg space includes `PS256`/`EdDSA`, which we cannot sign with); **document the ECDSA encoding contract on `CryptoService.sign`/`verify`**, which previously said nothing either way
- `tdf3/src/assertions.ts`: guard the unchecked `error.message` deref so a non-`Error` throw doesn't render as `undefined`

## Public API note

`CryptoService.sign()` is public and injectable via `clientConfig.cryptoService`. Its ECDSA output encoding changes from DER to raw P1363, and that contract is now written down in the interface docs. A custom implementation that returns DER will produce tokens conformant verifiers reject.

## Tests

- `tests/mocha/dpop-proof.spec.ts` — DPoP proofs (ES256/384/512, RS256) verified with `jose.jwtVerify`, plus tamper and wrong-key cases
- `tests/mocha/reqsignature-jws.spec.ts` — rewrap request token, same treatment
- `tests/mocha/helpers/jws-keys.ts` — shared WebCrypto→PEM→SDK key fixtures for both suites
- `tests/mocha/encrypt-decrypt.spec.ts` — end-to-end decrypt with an EC dpop key
- `tests/mocha/unit/crypto/crypto-service.spec.ts` — asserts `sign()` returns **exactly** 64/96/132 bytes per curve, over several draws. Exact width is the discriminator: DER for the same curves is 69–72 / 101–104 / 138–141 bytes, and roughly 1 raw signature in 256 happens to start with `0x30`, so the DER tag byte alone proves nothing. This replaces the old test that asserted `der[0] === 0x30` — which pinned the bug in place.
- `tests/mocha/unit/assertions.spec.ts` — pins the persisted `binding.signature` at 64 bytes for ES256, since that is the one signature this SDK writes to durable storage

## Test-gap follow-ups

The same symmetric-round-trip blind spot exists downstream. Filed: DSPX-4331 (js-lib-monorepo: cross-verify FIPS ECDSA against WebCrypto), DSPX-4332 (xtest: ES256 assertion fixture + SDK-independent manifest width check), DSPX-4333 (xtest: ES256 DPoP tests silently skip for the js SDK).

## How to test

`cd lib && npm test`
