### PR TITLE
fix(sdk): stop the legacy rewrap fallback from masking real KAS errors (DSPX-3397)

### DIFF
--- a/lib/src/access.ts
+++ b/lib/src/access.ts
@@ -1,12 +1,18 @@
+import { Code, ConnectError } from '@connectrpc/connect';
 import { type AuthConfig, resolveAuthConfig } from './auth/interceptors.js';
 import { RewrapResponse } from './platform/kas/kas_pb.js';
-import { getPlatformUrlFromKasEndpoint, validateSecureUrl } from './utils.js';
+import {
+  extractRpcErrorMessage,
+  getPlatformUrlFromKasEndpoint,
+  validateSecureUrl,
+} from './utils.js';
 import { base64 } from './encodings/index.js';
 import {
   KEY_ALGORITHMS,
   type KeyAlgorithm,
   isKeyAlgorithm,
 } from '../tdf3/src/crypto/declarations.js';
+import { InvalidFileError, PermissionDeniedError, UnauthenticatedError } from './errors.js';
 
 import {
   fetchKasBasePubKey,
@@ -57,21 +63,40 @@ export async function fetchWrappedKey(
     );
 
   // When no AuthProvider is available, skip the legacy fallback so the real
-  // RPC error propagates instead of being masked by tryPromisesUntilFirstSuccess.
+  // RPC error propagates instead of being masked.
   if (!authProvider) {
     return await rpcCall();
   }
 
-  return await tryPromisesUntilFirstSuccess(
+  // Try the modern Connect-RPC rewrap first, falling back to the legacy REST
+  // rewrap only for non-auth failures (older, non-Connect platforms). A
+  // definitive KAS auth/validation answer (401/403/400) surfaces as-is via
+  // tryRpcThenLegacy rather than being masked by the legacy 404 on
+  // Connect-only platforms.
+  // We intentionally omit the rewrap additional context from legacy requests:
+  // platforms new enough to know about obligations handle RPC successfully.
+  return await tryRpcThenLegacy(
     rpcCall,
-    // We intentionally do not provide the rewrap additional context to legacy requests destined for older platforms.
-    // Platforms new enough to have knowledge of obligations will be handling RPC requests successfully.
-    () =>
-      fetchWrappedKeysLegacy(
+    async () =>
+      (await fetchWrappedKeysLegacy(
         url,
         { signedRequestToken },
         authProvider
-      ) as unknown as Promise<RewrapResponse>
+      )) as unknown as RewrapResponse
+  );
+}
+
+/**
+ * An auth/validation error from the RPC rewrap represents a definitive answer
+ * from KAS and must not be masked by the legacy REST fallback (which 404s on
+ * Connect-only platforms). Other errors (network failures, or an old platform
+ * missing the Connect endpoint) remain eligible for the legacy fallback.
+ */
+function isRewrapAuthError(e: unknown): boolean {
+  return (
+    e instanceof UnauthenticatedError ||
+    e instanceof PermissionDeniedError ||
+    e instanceof InvalidFileError
   );
 }
 
@@ -190,7 +215,7 @@ export async function fetchKeyAccessServers(
     return await rpcCall();
   }
 
-  return await tryPromisesUntilFirstSuccess(rpcCall, () =>
+  return await tryRpcThenLegacy(rpcCall, () =>
     fetchKeyAccessServersLegacy(platformUrl, authProvider)
   );
 }
@@ -221,10 +246,13 @@ export async function fetchKasPubKey(
   try {
     return await fetchKasBasePubKey(kasEndpoint);
   } catch (e) {
-    console.log(e);
+    // Base key is optional; fall back to the RPC/legacy public-key path. Log a
+    // one-line summary via errBrief (never the raw error object, which for Connect
+    // errors can carry response metadata).
+    console.log(`base key fetch failed, falling back to RPC/legacy public key: ${errBrief(e)}`);
   }
 
-  return await tryPromisesUntilFirstSuccess(
+  return await tryRpcThenLegacy(
     () => fetchKasPubKeyRpc(kasEndpoint, algorithm),
     () => fetchKasPubKeyLegacy(kasEndpoint, algorithm)
   );
@@ -265,23 +293,44 @@ export class OriginAllowList {
 }
 
 /**
- * Tries two promise-returning functions in order and returns the first successful result.
- * If both fail, throws the error from the second.
- * @param first First function returning a promise to try.
- * @param second Second function returning a promise to try if the first fails.
+ * Try the modern Connect-RPC call first, falling back to the legacy REST call
+ * only for non-auth failures. A definitive auth/validation answer from the RPC
+ * layer short-circuits: the legacy endpoint 404s on Connect-only platforms and
+ * would otherwise mask the real error. On a double failure, surface the (more
+ * meaningful) RPC error while still logging the legacy one so the fallback path
+ * stays debuggable.
+ * @param rpcCall The modern Connect-RPC call to try first.
+ * @param legacyCall The legacy REST call to fall back to for non-auth failures.
+ * @param isAuthError Predicate identifying a definitive auth/validation error
+ *   that must surface as-is rather than trigger the legacy fallback.
  */
-async function tryPromisesUntilFirstSuccess<T>(
-  first: () => Promise<T>,
-  second: () => Promise<T>
+async function tryRpcThenLegacy<T>(
+  rpcCall: () => Promise<T>,
+  legacyCall: () => Promise<T>,
+  isAuthError: (e: unknown) => boolean = isRewrapAuthError
 ): Promise<T> {
   try {
-    return await first();
-  } catch (e1) {
-    console.info('v2 request error', e1);
+    return await rpcCall();
+  } catch (rpcError) {
+    if (isAuthError(rpcError)) {
+      throw rpcError;
+    }
+    console.info('v2 request error:', errBrief(rpcError));
     try {
-      return await second();
-    } catch (err) {
-      throw err;
+      return await legacyCall();
+    } catch (legacyError) {
+      console.info('legacy fallback also failed:', errBrief(legacyError));
+      throw rpcError;
     }
   }
+}
+
+/**
+ * A log-safe one-line summary of an error: its message (and Connect code), never
+ * the whole error object — Connect errors can carry response headers and
+ * metadata that should not be dumped to the console.
+ */
+function errBrief(e: unknown): string {
+  const message = extractRpcErrorMessage(e);
+  return e instanceof ConnectError ? `${Code[e.code]}: ${message}` : message;
 }

--- a/lib/src/access/access-rpc.ts
+++ b/lib/src/access/access-rpc.ts
@@ -29,10 +29,9 @@ import { ConnectError, Code } from '@connectrpc/connect';
 /**
  * Get a rewrapped access key to the document, if possible
  * @param url Key access server rewrap endpoint
- * @param requestBody a signed request with an encrypted document key
- * @param authProvider Authorization middleware
+ * @param signedRequestToken a signed request with an encrypted document key
+ * @param auth Authorization middleware
  * @param rewrapAdditionalContextHeader optional value for 'X-Rewrap-Additional-Context'
- * @param clientVersion
  */
 export async function fetchWrappedKey(
   url: string,
@@ -59,7 +58,6 @@ export async function fetchWrappedKey(
 
 export function handleRpcRewrapError(e: unknown, platformUrl: string): never {
   if (e instanceof ConnectError) {
-    console.log('Error is a ConnectError with code:', e.code);
     switch (e.code) {
       case Code.InvalidArgument: // 400 Bad Request
         throw new InvalidFileError(`400 for [${platformUrl}]: rewrap bad request [${e.message}]`);
@@ -217,7 +215,7 @@ export async function fetchKasPubKey(
 /**
  * Fetch the base public key from WellKnownConfiguration of the platform.
  * @param kasEndpoint The KAS endpoint URL.
- * @throws {ConfigurationError} If the KAS endpoint is not defined.
+ * @throws {ConfigurationError} If the KAS endpoint is not defined, or the platform config is missing its BaseKey.
  * @throws {NetworkError} If there is an error fetching the public key from the KAS endpoint.
  * @returns The base public key information for the KAS endpoint.
  */
@@ -235,7 +233,7 @@ export async function fetchKasBasePubKey(kasEndpoint: string): Promise<KasPublic
     const { configuration } = await platform.v1.wellknown.getWellKnownConfiguration({});
     const baseKey = configuration?.base_key as unknown as PlatformBaseKey;
     if (!isBaseKey(baseKey)) {
-      throw new NetworkError(
+      throw new ConfigurationError(
         `Invalid Platform Configuration: [${kasEndpoint}] is missing BaseKey in WellKnownConfiguration`
       );
     }
@@ -248,6 +246,12 @@ export async function fetchKasBasePubKey(kasEndpoint: string): Promise<KasPublic
     };
     return result;
   } catch (e) {
+    // A malformed platform config is not a network fault — re-throw it unchanged
+    // rather than masking it behind a [PublicKey] network-error banner. Only wrap
+    // genuine RPC/transport failures.
+    if (e instanceof ConfigurationError) {
+      throw e;
+    }
     throw new NetworkError(`[${platformUrl}] [PublicKey] ${extractRpcErrorMessage(e)}`);
   }
 }

--- a/lib/tests/mocha/encrypt-decrypt.spec.ts
+++ b/lib/tests/mocha/encrypt-decrypt.spec.ts
@@ -13,7 +13,12 @@ import {
   Assertion,
 } from '../../tdf3/src/assertions.js';
 import { Scope } from '../../tdf3/src/client/builders.js';
-import { NetworkError } from '../../src/errors.js';
+import {
+  NetworkError,
+  PermissionDeniedError,
+  ServiceError,
+  UnauthenticatedError,
+} from '../../src/errors.js';
 
 const Mocks = getMocks();
 
@@ -101,7 +106,9 @@ describe('rewrap error cases', function () {
       });
       assert.fail('Expected Error');
     } catch (error) {
-      assert.instanceOf(error, NetworkError);
+      // The real RPC auth error must surface; the legacy REST fallback no longer
+      // masks it with a 404/NetworkError (DSPX-3397).
+      assert.instanceOf(error, UnauthenticatedError);
     }
   });
 
@@ -125,7 +132,7 @@ describe('rewrap error cases', function () {
       });
       assert.fail('Expected Error');
     } catch (error) {
-      assert.instanceOf(error, NetworkError);
+      assert.instanceOf(error, PermissionDeniedError);
     }
   });
 
@@ -154,7 +161,7 @@ describe('rewrap error cases', function () {
       });
       assert.fail('Expected Error');
     } catch (error) {
-      assert.instanceOf(error, NetworkError);
+      assert.instanceOf(error, ServiceError);
     }
   });
 
@@ -178,7 +185,7 @@ describe('rewrap error cases', function () {
       });
       assert.fail('Expected ServiceError');
     } catch (error) {
-      assert.instanceOf(error, NetworkError);
+      assert.instanceOf(error, ServiceError);
     }
   });
 
@@ -233,10 +240,12 @@ describe('rewrap error cases', function () {
           location: encryptedStream.stream,
         },
       });
-      assert.fail('Expected InvalidFileError');
+      assert.fail('Expected ServiceError');
     } catch (error) {
-      assert.instanceOf(error, NetworkError);
-      assert.include(error.message, '404 Not Found');
+      // Previously the legacy REST fallback masked the real RPC error with a
+      // "404 Not Found" NetworkError; now the RPC error surfaces directly.
+      assert.instanceOf(error, ServiceError);
+      assert.notInclude((error as Error).message, '404 Not Found');
     }
   });
 });


### PR DESCRIPTION
Stack 2/6, split out of #939. Base: #987.

> Stack renumbered: the former 2/8 (`dspx-3397-2-der-hardening`, #988) is dropped — #987 now removes the DER code that PR hardened. GitHub still shows the old base branch here because it refuses to retarget a PR inside a stack; it should resolve once #988 is closed.

## What

`fetchWrappedKey` tries the Connect-RPC rewrap and falls back to the legacy REST rewrap for older platforms. The fallback ran on **every** RPC failure, so a definitive answer from KAS — 401 unauthenticated, 403 permission denied, 400 bad request — was discarded and replaced by the legacy endpoint's `404 Not Found` `NetworkError` on Connect-only platforms.

The practical effect: a caller with a bad token, a caller lacking entitlement, and a caller pointed at an unreachable server all got the same `NetworkError: ... 404 Not Found`.

## Changes

- `tryPromisesUntilFirstSuccess` → `tryRpcThenLegacy`, which short-circuits on auth/validation errors (`UnauthenticatedError`, `PermissionDeniedError`, `InvalidFileError`) and surfaces them as-is. Only network faults and missing-endpoint errors still fall back.
- On a double failure it throws the **RPC** error (the meaningful one) rather than the legacy 404, and logs the legacy failure so the fallback path stays debuggable.
- `fetchKasBasePubKey`: a platform config missing its `BaseKey` is a `ConfigurationError`, not a `NetworkError`, and is re-thrown unwrapped instead of being masked behind a `[PublicKey]` network-error banner.
- Log hygiene: log error summaries via `errBrief`, never raw error objects. A `ConnectError` carries response metadata — on the auth path that includes DPoP nonces — which should not be dumped to the console. `errBrief` wraps the existing `extractRpcErrorMessage` and adds the Connect code.
- Drops a stray unconditional `console.log('Error is a ConnectError with code:', ...)` from `handleRpcRewrapError`.

## Behavior change

This changes the error *type* callers see on rewrap failures. Four cases in `encrypt-decrypt.spec.ts` are updated to assert the specific error they were always meant to:

| case | before | after |
|---|---|---|
| bad token | `NetworkError` | `UnauthenticatedError` |
| forbidden | `NetworkError` | `PermissionDeniedError` |
| server error | `NetworkError` | `ServiceError` |
| bad kas url | `NetworkError` (`404 Not Found`) | `ServiceError` |

Worth a look from anyone depending on catching `NetworkError` broadly.

## How to test

`cd lib && npm test`