### PR TITLE
ci: upgrade roundtrip Keycloak to 26.2 and run kcadm in-container (DSPX-3397)

### DIFF
--- a/.github/workflows/roundtrip/config-demo-idp.sh
+++ b/.github/workflows/roundtrip/config-demo-idp.sh
@@ -2,31 +2,22 @@
 
 set -x
 
-: "${KC_VERSION:=24.0.3}"
+APP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 
-if ! which kcadm.sh; then
-  KCADM_URL=https://github.com/keycloak/keycloak/releases/download/${KC_VERSION}/keycloak-${KC_VERSION}.zip
-  echo "DOWNLOADING ${KCADM_URL}"
-  if ! curl --output kc.zip --fail --location "${KCADM_URL}"; then
-    echo "[ERROR] Failed to download ${KCADM_URL}"
-    exit 3
-  fi
-  ls -l
-  if ! unzip ./kc.zip; then
-    echo "[ERROR] Failed to unzip file from ${KCADM_URL}"
-    exit 3
-  fi
-  ls -l
-  ls -l "$(pwd)/keycloak-${KC_VERSION}/bin"
-  PATH=$PATH:"$(pwd)/keycloak-${KC_VERSION}/bin"
-  export PATH
-  if ! which kcadm.sh; then
-    echo "[ERROR] Failed to find kcadm.sh"
-    exit 3
-  fi
-fi
+# Run kcadm inside the keycloak container instead of downloading the release
+# zip. The container ships a JRE matching its own Keycloak version; the host
+# does not necessarily -- Keycloak 26's kcadm needs Java 17, while the
+# ubuntu-22.04 runner defaults to Java 11 (UnsupportedClassVersionError).
+# Using -f makes the compose project resolve from this script's directory, so
+# the caller's working directory doesn't matter.
+kcadm.sh() {
+  docker compose -f "${APP_DIR}/docker-compose.yaml" \
+    exec -T keycloak /opt/keycloak/bin/kcadm.sh "$@"
+}
 
-kcadm.sh config credentials --server http://localhost:65432/auth \
+# Inside the container Keycloak is reached on its own KC_HTTP_PORT, not through
+# the vite dev-server proxy on 65432 that host-side callers use.
+kcadm.sh config credentials --server http://localhost:8888/auth \
   --realm master --user admin --password changeme
 
 kcadm.sh create clients -r opentdf \
@@ -39,8 +30,7 @@ kcadm.sh create clients -r opentdf \
   -s serviceAccountsEnabled=false \
   -s publicClient=true \
   -s protocol=openid-connect \
-  -s 'protocolMappers=[{"name":"aud","protocol":"openid-connect","protocolMapper":"oidc-audience-mapper","consentRequired":false,"config":{"access.token.claim":"true","included.custom.audience":"http://localhost:65432"}}]' \
-  -s 'attributes={"dpop.bound.access.tokens":"true"}'
+  -s 'protocolMappers=[{"name":"aud","protocol":"openid-connect","protocolMapper":"oidc-audience-mapper","consentRequired":false,"config":{"access.token.claim":"true","included.custom.audience":"http://localhost:65432"}}]'
 
 kcadm.sh create clients -r opentdf \
   -s clientId=testclient \

--- a/.github/workflows/roundtrip/docker-compose.yaml
+++ b/.github/workflows/roundtrip/docker-compose.yaml
@@ -1,18 +1,12 @@
 services:
   keycloak:
-    image: keycloak/keycloak:24.0.5
+    image: keycloak/keycloak:26.2
     restart: always
     command:
     - "start-dev"
     - "--verbose"
     environment:
-      KC_DB_VENDOR: postgres
-      KC_DB_URL_HOST: keycloakdb
-      KC_DB_URL_PORT: 5432
-      KC_DB_URL_DATABASE: keycloak
-      KC_DB_USERNAME: keycloak
-      KC_DB_PASSWORD: changeme
-      KC_FEATURES: 'preview,token-exchange'
+      KC_FEATURES: "preview,token-exchange,admin-fine-grained-authz:v1"
       KC_HEALTH_ENABLED: 'true'
       KC_HOSTNAME_ADMIN_URL: 'http://localhost:65432/auth'
       KC_HOSTNAME_PORT: '65432'
@@ -29,24 +23,11 @@ services:
     ports:
       - '8888:8888'
     healthcheck:
-      test: ['CMD-SHELL', '[ -f /tmp/HealthCheck.java ] || echo "public class HealthCheck { public static void main(String[] args) throws java.lang.Throwable { System.exit(java.net.HttpURLConnection.HTTP_OK == ((java.net.HttpURLConnection)new java.net.URL(args[0]).openConnection()).getResponseCode() ? 0 : 1); } }" > /tmp/HealthCheck.java && java /tmp/HealthCheck.java http://localhost:8888/auth/health/live']
+      test: ['CMD-SHELL', '[ -f /tmp/HealthCheck.java ] || echo "public class HealthCheck { public static void main(String[] args) throws java.lang.Throwable { System.exit(java.net.HttpURLConnection.HTTP_OK == ((java.net.HttpURLConnection)new java.net.URL(args[0]).openConnection()).getResponseCode() ? 0 : 1); } }" > /tmp/HealthCheck.java && java /tmp/HealthCheck.java http://localhost:9000/auth/health/live']
       interval: 5s
       timeout: 10s
       retries: 3
       start_period: 2m
-  keycloakdb:
-    image: postgres:15-alpine
-    restart: always
-    user: postgres
-    environment:
-      POSTGRES_PASSWORD: changeme
-      POSTGRES_USER: postgres
-      POSTGRES_DB: keycloak
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready"]
-      interval: 5s
-      timeout: 5s
-      retries: 10
   opentdfdb:
     image: postgres:15-alpine
     restart: always

--- a/.github/workflows/roundtrip/wait-and-test.sh
+++ b/.github/workflows/roundtrip/wait-and-test.sh
@@ -115,7 +115,7 @@ _init_platform() {
     return 1
   fi
   if ! ./config-demo-idp.sh; then
-    echo "[ERROR] unable to provision keycloak"
+    echo "[ERROR] unable to configure demo idp clients"
     return 1
   fi
   if ! ./init-temp-keys.sh; then


### PR DESCRIPTION
Stack 3/6, split out of #939. Base: #989.

## What

Keycloak 24.0.5 predates DPoP support, so the roundtrip job cannot exercise DPoP-bound tokens at all. Upgrading to 26.2 is the prerequisite for the DPoP work in stack 5/6; it is separated here so the infrastructure change can be validated on its own.

## Changes

**`kcadm.sh` runs in the container now.** Keycloak 26's `kcadm` needs Java 17; the `ubuntu-22.04` runner defaults to Java 11 and fails with `UnsupportedClassVersionError`. `config-demo-idp.sh` shells into the keycloak container (which ships a matching JRE) through a `kcadm.sh` shell function. Passing `-f` makes compose resolve the project from the script's own directory, so the caller's working directory no longer matters.

This also deletes the release-zip download-and-unzip block — one less network dependency in CI, and the version can't drift from the running server.

**Health check port.** Management endpoints, including `/health/live`, moved to 9000 in Keycloak 25+.

**Drops the `keycloakdb` postgres service.** `start-dev` uses the embedded H2 database, so the external postgres was already unused. Removes a container from the job.

**Adds `admin-fine-grained-authz:v1`** to `KC_FEATURES`, which 26.x requires as an explicit flag for the admin API calls this script makes.

## Risk

This is CI-only — no `lib/`, `cli/`, or `web-app/` code is touched. The signal is the roundtrip job itself passing.

## How to test

The roundtrip workflow on this PR.