### PR TITLE
feat(sdk): cache ListKeyAccessServers response during decryption

### DIFF
--- a/lib/src/access.ts
+++ b/lib/src/access.ts
@@ -239,6 +239,22 @@ const origin = (u: string): string => {
   }
 };
 
+export type KasAllowListCache = Map<string, Promise<OriginAllowList>>;
+
+export function fetchKeyAccessServersWithCache(
+  cache: KasAllowListCache,
+  platformUrl: string,
+  auth: AuthConfig
+): Promise<OriginAllowList> {
+  const cached = cache.get(platformUrl);
+  if (cached) {
+    return cached;
+  }
+  const promise = fetchKeyAccessServers(platformUrl, auth);
+  cache.set(platformUrl, promise);
+  return promise;
+}
+
 /**
  * Manages a list of origins that are allowed to access the Key Access Server (KAS).
  * @origins A list of origins that are allowed to access the KAS.

--- a/lib/src/access.ts
+++ b/lib/src/access.ts
@@ -250,7 +250,12 @@ export function fetchKeyAccessServersWithCache(
   if (cached) {
     return cached;
   }
-  const promise = fetchKeyAccessServers(platformUrl, auth);
+  const promise = fetchKeyAccessServers(platformUrl, auth).catch((e) => {
+    if (cache.get(platformUrl) === promise) {
+      cache.delete(platformUrl);
+    }
+    throw e;
+  });
   cache.set(platformUrl, promise);
   return promise;
 }

--- a/lib/src/opentdf.ts
+++ b/lib/src/opentdf.ts
@@ -12,10 +12,10 @@ import {
   AssertionVerificationKeys,
 } from '../tdf3/src/assertions.js';
 import {
+  fetchKeyAccessServersWithCache,
   type KasPublicKeyAlgorithm,
   OriginAllowList,
   PUBLIC_KEY_ALGORITHMS,
-  fetchKeyAccessServers,
   isPublicKeyAlgorithm,
 } from './access.js';
 import { type Manifest } from '../tdf3/src/models/manifest.js';
@@ -534,7 +534,7 @@ class ZTDFReader {
         this.opts.ignoreAllowlist
       );
     } else if (this.opts.platformUrl) {
-      allowList = await fetchKeyAccessServers(this.opts.platformUrl, auth);
+      allowList = await fetchKeyAccessServersWithCache(this.client.kasAllowListCache, this.opts.platformUrl, auth);
     }
 
     const overview = await this.overview;

--- a/lib/src/opentdf.ts
+++ b/lib/src/opentdf.ts
@@ -534,7 +534,11 @@ class ZTDFReader {
         this.opts.ignoreAllowlist
       );
     } else if (this.opts.platformUrl) {
-      allowList = await fetchKeyAccessServersWithCache(this.client.kasAllowListCache, this.opts.platformUrl, auth);
+      allowList = await fetchKeyAccessServersWithCache(
+        this.client.kasAllowListCache,
+        this.opts.platformUrl,
+        auth
+      );
     }
 
     const overview = await this.overview;

--- a/lib/tdf3/src/client/index.ts
+++ b/lib/tdf3/src/client/index.ts
@@ -37,7 +37,8 @@ import {
 } from './builders.js';
 import { DecoratedReadableStream } from './DecoratedReadableStream.js';
 import {
-  fetchKeyAccessServers,
+  fetchKeyAccessServersWithCache,
+  type KasAllowListCache,
   type KasPublicKeyInfo,
   OriginAllowList,
 } from '../../../src/access.js';
@@ -353,6 +354,8 @@ export class Client {
   readonly platformUrl?: string;
 
   readonly kasKeyInfoCache: KasKeyInfoCache = [];
+
+  readonly kasAllowListCache: KasAllowListCache = new Map();
 
   readonly easEndpoint?: string;
 
@@ -815,7 +818,7 @@ export class Client {
     if (!allowList && this.allowedKases) {
       allowList = this.allowedKases;
     } else if (this.platformUrl) {
-      allowList = await fetchKeyAccessServers(this.platformUrl, this.auth);
+      allowList = await fetchKeyAccessServersWithCache(this.kasAllowListCache, this.platformUrl, this.auth);
     } else {
       throw new ConfigurationError('platformUrl is required when allowedKases is empty');
     }

--- a/lib/tdf3/src/client/index.ts
+++ b/lib/tdf3/src/client/index.ts
@@ -818,7 +818,11 @@ export class Client {
     if (!allowList && this.allowedKases) {
       allowList = this.allowedKases;
     } else if (this.platformUrl) {
-      allowList = await fetchKeyAccessServersWithCache(this.kasAllowListCache, this.platformUrl, this.auth);
+      allowList = await fetchKeyAccessServersWithCache(
+        this.kasAllowListCache,
+        this.platformUrl,
+        this.auth
+      );
     } else {
       throw new ConfigurationError('platformUrl is required when allowedKases is empty');
     }

--- a/lib/tests/web/access/access.test.ts
+++ b/lib/tests/web/access/access.test.ts
@@ -41,6 +41,32 @@ describe('fetchKeyAccessServersWithCache', () => {
 
     expect(fetchStub.callCount).to.equal(2);
   });
+
+  it('should evict a rejected entry and retry on the next call', async () => {
+    const auth = { interceptors: [] };
+    const cache: KasAllowListCache = new Map();
+    const platformUrl = 'http://localhost:3000';
+
+    fetchStub.callsFake(() => Promise.reject(new Error('network down')));
+
+    try {
+      await fetchKeyAccessServersWithCache(cache, platformUrl, auth);
+    } catch {
+      // expected
+    }
+
+    // Wait a tick for the .catch() eviction handler to run
+    await new Promise((r) => setTimeout(r, 0));
+    expect(cache.has(platformUrl)).to.equal(false);
+
+    fetchStub.callsFake(() =>
+      Promise.resolve(new Response('{}', { headers: { 'Content-Type': 'application/json' } }))
+    );
+
+    const result = await fetchKeyAccessServersWithCache(cache, platformUrl, auth);
+    expect(result).to.not.be.undefined;
+    expect(fetchStub.callCount).to.equal(2);
+  });
 });
 
 describe('rewrapAdditionalContextHeader', () => {

--- a/lib/tests/web/access/access.test.ts
+++ b/lib/tests/web/access/access.test.ts
@@ -22,12 +22,14 @@ describe('fetchKeyAccessServersWithCache', () => {
     sinon.restore();
   });
 
-  it('should only fetch the KAS list once for repeated calls with the same platformUrl', async () => {
+  it('should deduplicate concurrent calls for the same platformUrl', async () => {
     const auth = { interceptors: [] };
     const cache: KasAllowListCache = new Map();
     const platformUrl = 'http://localhost:3000';
-    const result1 = await fetchKeyAccessServersWithCache(cache, platformUrl, auth);
-    const result2 = await fetchKeyAccessServersWithCache(cache, platformUrl, auth);
+    const [result1, result2] = await Promise.all([
+      fetchKeyAccessServersWithCache(cache, platformUrl, auth),
+      fetchKeyAccessServersWithCache(cache, platformUrl, auth),
+    ]);
 
     expect(result1).to.equal(result2);
     expect(fetchStub.callCount).to.equal(1);

--- a/lib/tests/web/access/access.test.ts
+++ b/lib/tests/web/access/access.test.ts
@@ -1,9 +1,47 @@
 import { expect } from 'chai';
+import sinon from 'sinon';
 import {
+  fetchKeyAccessServersWithCache,
+  type KasAllowListCache,
   rewrapAdditionalContextHeader,
   type RewrapAdditionalContext,
 } from '../../../src/access.js';
 import { base64 } from '../../../src/encodings/index.js';
+
+describe('fetchKeyAccessServersWithCache', () => {
+  let fetchStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    fetchStub = sinon.stub(globalThis, 'fetch');
+    fetchStub.callsFake(() =>
+      Promise.resolve(new Response('{}', { headers: { 'Content-Type': 'application/json' } }))
+    );
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should only fetch the KAS list once for repeated calls with the same platformUrl', async () => {
+    const auth = { interceptors: [] };
+    const cache: KasAllowListCache = new Map();
+    const platformUrl = 'http://localhost:3000';
+    const result1 = await fetchKeyAccessServersWithCache(cache, platformUrl, auth);
+    const result2 = await fetchKeyAccessServersWithCache(cache, platformUrl, auth);
+
+    expect(result1).to.equal(result2);
+    expect(fetchStub.callCount).to.equal(1);
+  });
+
+  it('should fetch separately for different platformUrls', async () => {
+    const auth = { interceptors: [] };
+    const cache: KasAllowListCache = new Map();
+    await fetchKeyAccessServersWithCache(cache, 'http://platform-a.example.com', auth);
+    await fetchKeyAccessServersWithCache(cache, 'http://platform-b.example.com', auth);
+
+    expect(fetchStub.callCount).to.equal(2);
+  });
+});
 
 describe('rewrapAdditionalContextHeader', () => {
   it('should return undefined for empty array', () => {


### PR DESCRIPTION
## Motivation

Every `decrypt()` call triggers a `ListKeyAccessServers` RPC to build the KAS allowlist, with no caching. Decrypting N files means N identical RPCs. KAS public keys are already cached on the `Client` instance, but the server list was not.

Closes #998

## PR Changes

- Added `fetchKeyAccessServersWithCache` function and `KasAllowListCache` type alias in `lib/src/access.ts`. Caches the promise per `platformUrl` for the lifetime of the `Client` instance, matching the existing `kasKeyInfoCache` pattern.
- Added `kasAllowListCache` field to `Client` in `lib/tdf3/src/client/index.ts` and wired it into `Client.decrypt()`.
- Updated `ZTDFReader.decrypt()` in `lib/src/opentdf.ts` to use the cache via `this.client.kasAllowListCache`.
- Added unit tests in `lib/tests/web/access/access.test.ts` verifying the cache deduplicates calls for the same `platformUrl` and fetches separately for different ones.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved decryption performance by reusing previously retrieved key access server allowlists.
  - Prevents duplicate network requests for the same platform URL while maintaining separate lookups for different URLs.

- **Bug Fixes**
  - Failed allowlist requests no longer prevent subsequent retry attempts.

- **Tests**
  - Added coverage for concurrent cache reuse, independent platform URL requests, and retry behavior after failed requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->