### PR TITLE
feat(main): surface wrap and rewrap algorithm choice in web-app demo (DSPX-3229)

### DIFF
--- a/.github/workflows/roundtrip/.gitignore
+++ b/.github/workflows/roundtrip/.gitignore
@@ -5,12 +5,21 @@
 # Platform checkout (CI clones it here; locally it is usually a symlink)
 /platform
 
-# KAS keys and CA material from ./init-temp-keys.sh
+# KAS keys and CA material from ./init-temp-keys.sh. The CA serial lands in
+# keys/ alongside the cert it numbers, so /keys/ already covers it.
 /*.pem
-/*.srl
 /ecparams.tmp
 /keys/
 
 # Keycloak admin CLI downloaded by ./config-demo-idp.sh
 /kc.zip
 /keycloak-*/
+
+# ./wait-and-test.sh installs the packed CLI tarball here; only package.json is
+# tracked, so the lock file it generates is throwaway.
+/package-lock.json
+
+# Round-trip fixtures from ./encrypt-decrypt.sh. It only removes these on the
+# success path, and it is `set -e`, so a failed run strands them.
+/sample*.txt
+/sample*.tdf

--- a/.github/workflows/roundtrip/.gitignore
+++ b/.github/workflows/roundtrip/.gitignore
@@ -1,0 +1,16 @@
+# Local backend bring-up artifacts. In CI these live on a throwaway runner, but
+# when running the harness locally they land in this directory. See the
+# roundtrip README steps in web-app/tests/README.md.
+
+# Platform checkout (CI clones it here; locally it is usually a symlink)
+/platform
+
+# KAS keys and CA material from ./init-temp-keys.sh
+/*.pem
+/*.srl
+/ecparams.tmp
+/keys/
+
+# Keycloak admin CLI downloaded by ./config-demo-idp.sh
+/kc.zip
+/keycloak-*/

--- a/web-app/src/App.css
+++ b/web-app/src/App.css
@@ -97,11 +97,15 @@
   flex: 0 1 auto;
 }
 
-.horizontal-flow {
-  display: flex;
-  align-items: bottom;
-  flex-wrap: wrap;
-  gap: 1em;
+/* The requested wrap algorithm and the one the KAS actually used can differ;
+   when they do, say so somewhere the progress counter won't overwrite. */
+.warning {
+  background-color: #fff3cd;
+  border: 1px solid #e0a800;
+  border-radius: 0.5em;
+  color: #664d03;
+  flex: 1 1 20em;
+  padding: 0.5em 0.75em;
 }
 
 .selected {

--- a/web-app/src/App.css
+++ b/web-app/src/App.css
@@ -13,16 +13,94 @@
   margin-left: 10px;
 }
 
+/* The session tokens are long unbroken strings. Keep them in their own scroll
+   box: unconstrained they set the page's minimum width and the whole layout
+   scrolls sideways, but wrapping them instead turns the header into thousands
+   of lines. */
+#user_token {
+  flex: 1;
+  max-height: 6em;
+  min-width: 0;
+  overflow: auto;
+  white-space: pre;
+}
+
+.body {
+  padding: 0 24px 2em;
+}
+
+/* Steps stack top to bottom in the order you work through them: choose a
+   source and sink, encrypt or decrypt, then read the output. Within a step,
+   left to right is action then the options that affect it. */
+.step {
+  margin: 1.5em 0;
+}
+
+.step > h2 {
+  font-size: 1.1em;
+  letter-spacing: 0.04em;
+  margin: 0 0 0.5em;
+  text-transform: uppercase;
+}
+
+/* Encrypt and decrypt are peers: pair them on one row when the viewport can
+   fit both, otherwise let them stack. */
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5em 2em;
+  margin: 1.5em 0;
+}
+
+/* Spacing comes from the container's gap; flex children don't collapse
+   margins, so leaving the .step margin on would double it when stacked. */
+.actions > .step {
+  flex: 0 1 auto;
+  margin: 0;
+}
+
+.step-body {
+  align-items: flex-start;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1em;
+}
+
+.step-body > fieldset {
+  flex: 1 1 15em;
+  min-width: 0;
+}
+
+/* inline-flex so the action bar hugs its button and options instead of
+   stretching into a wide empty slab on a desktop viewport. */
 .card {
-  border-radius: 1em;
-  padding: 2em;
-  margin: 1em;
+  align-items: center;
   background-color: cadetblue;
+  border-radius: 1em;
+  display: inline-flex;
+  padding: 1em;
+}
+
+/* Per-step options, sitting on the action card. */
+.options {
+  border: 1px solid rgba(255, 255, 255, 0.5);
+  border-radius: 0.5em;
+}
+
+.options legend {
+  font-size: 0.8em;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.status {
+  flex: 0 1 auto;
 }
 
 .horizontal-flow {
   display: flex;
   align-items: bottom;
+  flex-wrap: wrap;
   gap: 1em;
 }
 
@@ -33,4 +111,50 @@
 textarea {
   width: 100%;
   height: 200px;
+}
+
+/* Manifest Inspector */
+/* Needs to outrank `.step-body > fieldset` on specificity, hence the child
+   selector: the inspector should size to its content, not stretch. */
+.step-body > .inspector {
+  flex: 0 1 28em;
+}
+
+.kao-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.kao + .kao {
+  border-top: 1px solid #ccc;
+  margin-top: 0.75em;
+  padding-top: 0.75em;
+}
+
+.kao h3 {
+  font-size: 0.8em;
+  letter-spacing: 0.06em;
+  margin: 0 0 0.6em;
+  opacity: 0.7;
+  text-transform: uppercase;
+}
+
+.kao dl {
+  display: grid;
+  /* minmax(0, …) so a long kas url wraps rather than widening the column. */
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 0.4em 0.8em;
+  margin: 0;
+}
+
+.kao dt {
+  opacity: 0.7;
+  white-space: nowrap;
+}
+
+.kao dd {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  margin: 0;
+  overflow-wrap: anywhere;
 }

--- a/web-app/src/App.tsx
+++ b/web-app/src/App.tsx
@@ -3,7 +3,14 @@ import { useState, useEffect, type ChangeEvent } from 'react';
 import streamsaver from 'streamsaver';
 import { showSaveFilePicker } from 'native-file-system-adapter';
 import './App.css';
-import { type Chunker, type KasPublicKeyAlgorithm, type Source, OpenTDF } from '@opentdf/sdk';
+import {
+  type Chunker,
+  type DecoratedStream,
+  type KasPublicKeyAlgorithm,
+  type Manifest,
+  type Source,
+  OpenTDF,
+} from '@opentdf/sdk';
 import { type SessionInformation, OidcClient } from './session.js';
 import { config } from './config.js';
 
@@ -141,6 +148,19 @@ function decodedBase64Length(value: string): number {
   return Math.floor((value.length * 3) / 4) - paddingLength;
 }
 
+function kaoMetadataFrom(manifest: Manifest): KaoMetadata[] {
+  return manifest.encryptionInformation.keyAccess.map((kao) => {
+    const wrappedKeyBytes = kao.wrappedKey ? decodedBase64Length(kao.wrappedKey) : 0;
+    return {
+      kid: kao.kid ?? '(no kid)',
+      type: kao.type,
+      url: kao.url,
+      protocol: kao.protocol,
+      wrappedKeyBytes,
+    } satisfies KaoMetadata;
+  });
+}
+
 function fileNameFor(inputSource: InputSource) {
   if (!inputSource) {
     return 'undefined.bin';
@@ -256,6 +276,7 @@ function App() {
   const [inputSource, setInputSource] = useState<InputSource | undefined>();
   const [sinkType, setSinkType] = useState<SinkType>('file');
   const [encapAlgorithm, setEncapAlgorithm] = useState<KasPublicKeyAlgorithm>('ec:secp256r1');
+  const [rewrapAlgorithm, setRewrapAlgorithm] = useState<KasPublicKeyAlgorithm>('rsa:2048');
   const [kaoMetadata, setKaoMetadata] = useState<KaoMetadata[] | undefined>();
   const [streamController, setStreamController] = useState<CurrentDataController>();
 
@@ -419,7 +440,7 @@ function App() {
     }
     const progressTransformers = makeProgressPair(size, 'Encrypt');
 
-    let cipherText: ReadableStream<Uint8Array>;
+    let cipherText: DecoratedStream;
     try {
       cipherText = await client.createZTDF({
         autoconfigure: false,
@@ -431,6 +452,12 @@ function App() {
       console.error('Encrypt Failed', e);
       return;
     }
+    // Surface the key access objects we just wrote, so the wrap algorithm choice
+    // is visible without having to decrypt first. Don't await; this shouldn't
+    // hold up the download.
+    cipherText.manifest
+      ?.then((manifest) => setKaoMetadata(kaoMetadataFrom(manifest)))
+      .catch((e) => console.warn('failed to read manifest after encrypt', e));
     const cipherTextWithProgress = cipherText.pipeThrough(progressTransformers.writer);
     try {
       switch (sinkType) {
@@ -467,6 +494,9 @@ function App() {
     }
     const dfn = decryptedFileName(fileNameFor(inputSource));
     console.log(`Decrypting ${JSON.stringify(inputSource)} to ${sinkType} ${dfn}`);
+    // Drop anything left over from a previous encrypt or decrypt so the panel
+    // always reflects the file we're reading now.
+    setKaoMetadata(undefined);
     let f: FileSystemFileHandle | undefined;
     if (sinkType === 'fsapi') {
       f = await getNewFileHandle(decryptedFileExtension(fileNameFor(inputSource)), dfn);
@@ -479,6 +509,7 @@ function App() {
       authProvider: oidcClient,
       defaultReadOptions: {
         allowedKASEndpoints: [config.kas],
+        wrappingKeyAlgorithm: rewrapAlgorithm,
         ...decryptReadTuning,
       },
       dpopKeys: oidcClient.getSigningKey(),
@@ -512,17 +543,7 @@ function App() {
       const reader = client.open({ source });
       try {
         const manifest = await reader.manifest();
-        const kaos = manifest.encryptionInformation.keyAccess.map((kao) => {
-          const wrappedKeyBytes = kao.wrappedKey ? decodedBase64Length(kao.wrappedKey) : 0;
-          return {
-            kid: kao.kid ?? '(no kid)',
-            type: kao.type,
-            url: kao.url,
-            protocol: kao.protocol,
-            wrappedKeyBytes,
-          } satisfies KaoMetadata;
-        });
-        setKaoMetadata(kaos);
+        setKaoMetadata(kaoMetadataFrom(manifest));
       } catch (e) {
         console.warn('failed to read manifest for KAO inspection', e);
         setKaoMetadata(undefined);
@@ -682,11 +703,24 @@ function App() {
           <fieldset>
             <legend>Encapsulation Algorithm</legend>
             <div>
-              <label htmlFor="encapAlgorithm">Key wrap algorithm:</label>{' '}
+              <label htmlFor="encapAlgorithm">Wrap key algorithm (encrypt):</label>{' '}
               <select
                 id="encapAlgorithm"
                 value={encapAlgorithm}
                 onChange={(e) => setEncapAlgorithm(e.target.value as KasPublicKeyAlgorithm)}
+              >
+                <option value="ec:secp256r1">EC P-256</option>
+                <option value="rsa:2048">RSA-2048</option>
+                <option value="mlkem:768">ML-KEM-768</option>
+                <option value="mlkem:1024">ML-KEM-1024</option>
+              </select>
+            </div>
+            <div>
+              <label htmlFor="rewrapAlgorithm">Rewrap key algorithm (decrypt):</label>{' '}
+              <select
+                id="rewrapAlgorithm"
+                value={rewrapAlgorithm}
+                onChange={(e) => setRewrapAlgorithm(e.target.value as KasPublicKeyAlgorithm)}
               >
                 <option value="ec:secp256r1">EC P-256</option>
                 <option value="rsa:2048">RSA-2048</option>

--- a/web-app/src/App.tsx
+++ b/web-app/src/App.tsx
@@ -608,194 +608,210 @@ function App() {
         {SessionInfo}
       </div>
       <div className="body">
-        <div className="config horizontal-flow">
-          <fieldset className="input">
-            <legend>Source</legend>
-            {hasFileInput ? (
-              <div id="details">
-                <h2>{'file' in inputSource ? inputSource.file.name : '[rand]'}</h2>
-                {'file' in inputSource && (
-                  <>
-                    <div id="contentType">Content Type: {inputSource.file.type}</div>
-                    <div>
-                      Last Modified: {new Date(inputSource.file.lastModified).toLocaleString()}
-                    </div>
-                    <div>Size: {new Intl.NumberFormat().format(inputSource.file.size)} bytes</div>
-                  </>
-                )}
-                <button
-                  id="clearFile"
-                  onClick={() => {
-                    setInputSource(undefined);
-                    setDownloadState(undefined);
-                  }}
-                  type="button"
-                >
-                  Clear file
-                </button>
-              </div>
-            ) : (
-              <>
-                <label htmlFor="fileSelector">Select file:</label>
-                <input type="file" name="file" id="fileSelector" onChange={setFileHandler} />
-                <div>OR</div>
-                <div className={clsx({ selected: inputSource && 'url' in inputSource })}>
-                  <label htmlFor="urlSelector">Load from URL:</label>
-                  <input
-                    id="urlSelector"
-                    name="url"
-                    onChange={setUrlHandler}
-                    placeholder="http://localhost:8000/sample.tdf"
-                    type="url"
-                  />
+        <section className="step">
+          <div className="step-body">
+            <fieldset className="input">
+              <legend>Source</legend>
+              {hasFileInput ? (
+                <div id="details">
+                  <h2>{'file' in inputSource ? inputSource.file.name : '[rand]'}</h2>
+                  {'file' in inputSource && (
+                    <>
+                      <div id="contentType">Content Type: {inputSource.file.type}</div>
+                      <div>
+                        Last Modified: {new Date(inputSource.file.lastModified).toLocaleString()}
+                      </div>
+                      <div>Size: {new Intl.NumberFormat().format(inputSource.file.size)} bytes</div>
+                    </>
+                  )}
+                  <button
+                    id="clearFile"
+                    onClick={() => {
+                      setInputSource(undefined);
+                      setDownloadState(undefined);
+                    }}
+                    type="button"
+                  >
+                    Clear file
+                  </button>
                 </div>
-                <div>OR:</div>
-                <div className={clsx({ selected: inputSource && 'length' in inputSource })}>
-                  <label htmlFor="randomSelector">Random Bytes:</label>
-                  <input
-                    id="randomSelector"
-                    name="randomSelector"
-                    min="0"
-                    max={2 ** 34}
-                    onChange={setRandomHandler}
-                    placeholder={`${2 ** 20} bytes`}
-                    type="number"
-                  />
-                </div>
-              </>
-            )}
-          </fieldset>
-
-          <fieldset className="Output">
-            <legend>Sink</legend>
-            <div>
-              <input
-                type="radio"
-                id="fileSink"
-                name="sinkType"
-                value="file"
-                onChange={(e) => setSinkType(e.target.value as SinkType)}
-                checked={sinkType === 'file'}
-              />{' '}
-              <label htmlFor="fileSink">Download</label>
-              <br />
-              <input
-                type="radio"
-                id="fsapiSink"
-                name="sinkType"
-                value="fsapi"
-                onChange={(e) => setSinkType(e.target.value as SinkType)}
-                checked={sinkType === 'fsapi'}
-              />{' '}
-              <label htmlFor="fsapiSink">Save As</label>
-              <br />
-              <input
-                type="radio"
-                id="noneSink"
-                name="sinkType"
-                value="none"
-                onChange={(e) => setSinkType(e.target.value as SinkType)}
-                checked={sinkType === 'none'}
-              />{' '}
-              <label htmlFor="noneSink">Dump</label>
-            </div>
-          </fieldset>
-          <fieldset>
-            <legend>Encapsulation Algorithm</legend>
-            <div>
-              <label htmlFor="encapAlgorithm">Wrap key algorithm (encrypt):</label>{' '}
-              <select
-                id="encapAlgorithm"
-                value={encapAlgorithm}
-                onChange={(e) => setEncapAlgorithm(e.target.value as KasPublicKeyAlgorithm)}
-              >
-                <option value="ec:secp256r1">EC P-256</option>
-                <option value="rsa:2048">RSA-2048</option>
-                <option value="mlkem:768">ML-KEM-768</option>
-                <option value="mlkem:1024">ML-KEM-1024</option>
-              </select>
-            </div>
-            <div>
-              <label htmlFor="rewrapAlgorithm">Rewrap key algorithm (decrypt):</label>{' '}
-              <select
-                id="rewrapAlgorithm"
-                value={rewrapAlgorithm}
-                onChange={(e) => setRewrapAlgorithm(e.target.value as KasPublicKeyAlgorithm)}
-              >
-                <option value="ec:secp256r1">EC P-256</option>
-                <option value="rsa:2048">RSA-2048</option>
-                <option value="mlkem:768">ML-KEM-768</option>
-                <option value="mlkem:1024">ML-KEM-1024</option>
-              </select>
-            </div>
-          </fieldset>
-          {kaoMetadata && kaoMetadata.length > 0 && (
-            <fieldset>
-              <legend>Manifest Inspector</legend>
-              <table id="kaoMetadata">
-                <thead>
-                  <tr>
-                    <th>#</th>
-                    <th>kid</th>
-                    <th>type</th>
-                    <th>protocol</th>
-                    <th>wrappedKey bytes</th>
-                    <th>kas url</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {kaoMetadata.map((kao, idx) => (
-                    <tr key={idx} id={`kao-row-${idx}`}>
-                      <td>{idx}</td>
-                      <td id={`kao-kid-${idx}`}>{kao.kid}</td>
-                      <td id={`kao-type-${idx}`}>{kao.type}</td>
-                      <td id={`kao-protocol-${idx}`}>{kao.protocol}</td>
-                      <td id={`kao-wrapped-bytes-${idx}`}>{kao.wrappedKeyBytes}</td>
-                      <td id={`kao-url-${idx}`}>{kao.url}</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
+              ) : (
+                <>
+                  <label htmlFor="fileSelector">Select file:</label>
+                  <input type="file" name="file" id="fileSelector" onChange={setFileHandler} />
+                  <div>OR</div>
+                  <div className={clsx({ selected: inputSource && 'url' in inputSource })}>
+                    <label htmlFor="urlSelector">Load from URL:</label>
+                    <input
+                      id="urlSelector"
+                      name="url"
+                      onChange={setUrlHandler}
+                      placeholder="http://localhost:8000/sample.tdf"
+                      type="url"
+                    />
+                  </div>
+                  <div>OR:</div>
+                  <div className={clsx({ selected: inputSource && 'length' in inputSource })}>
+                    <label htmlFor="randomSelector">Random Bytes:</label>
+                    <input
+                      id="randomSelector"
+                      name="randomSelector"
+                      min="0"
+                      max={2 ** 34}
+                      onChange={setRandomHandler}
+                      placeholder={`${2 ** 20} bytes`}
+                      type="number"
+                    />
+                  </div>
+                </>
+              )}
             </fieldset>
-          )}
-        </div>
+
+            <fieldset className="Output">
+              <legend>Sink</legend>
+              <div>
+                <input
+                  type="radio"
+                  id="fileSink"
+                  name="sinkType"
+                  value="file"
+                  onChange={(e) => setSinkType(e.target.value as SinkType)}
+                  checked={sinkType === 'file'}
+                />{' '}
+                <label htmlFor="fileSink">Download</label>
+                <br />
+                <input
+                  type="radio"
+                  id="fsapiSink"
+                  name="sinkType"
+                  value="fsapi"
+                  onChange={(e) => setSinkType(e.target.value as SinkType)}
+                  checked={sinkType === 'fsapi'}
+                />{' '}
+                <label htmlFor="fsapiSink">Save As</label>
+                <br />
+                <input
+                  type="radio"
+                  id="noneSink"
+                  name="sinkType"
+                  value="none"
+                  onChange={(e) => setSinkType(e.target.value as SinkType)}
+                  checked={sinkType === 'none'}
+                />{' '}
+                <label htmlFor="noneSink">Dump</label>
+              </div>
+            </fieldset>
+          </div>
+        </section>
 
         {streamController && (
-          <div className="action">
-            <button
-              id="cancelStream"
-              onClick={async () => {
-                console.log(`Cancelling !!!!`);
-                const p = streamController.abort();
-                setStreamController(undefined);
-                await p;
-              }}
-              type="button"
-            >
-              CANCEL
-            </button>
-          </div>
+          <section className="step">
+            <div className="step-body card">
+              <button
+                id="cancelStream"
+                onClick={async () => {
+                  console.log(`Cancelling !!!!`);
+                  const p = streamController.abort();
+                  setStreamController(undefined);
+                  await p;
+                }}
+                type="button"
+              >
+                CANCEL
+              </button>
+            </div>
+          </section>
         )}
         {inputSource && !streamController && (
-          <div className="action">
-            <form className="column">
+          <div className="actions">
+            {/* Encrypt and decrypt are alternatives rather than sequential steps,
+                so they sit side by side when there is room and stack when there
+                isn't. Each carries the options that affect it to its right. */}
+            <section className="step">
               <h2>Encrypt</h2>
-              <div className="card horizontal-flow">
+              <div className="step-body card">
                 <button id="encryptButton" onClick={() => handleEncrypt()} type="button">
                   Encrypt
                 </button>
+                <fieldset className="options">
+                  <legend>Options</legend>
+                  <label htmlFor="encapAlgorithm">Wrap key algorithm</label>{' '}
+                  <select
+                    id="encapAlgorithm"
+                    value={encapAlgorithm}
+                    onChange={(e) => setEncapAlgorithm(e.target.value as KasPublicKeyAlgorithm)}
+                  >
+                    <option value="ec:secp256r1">EC P-256</option>
+                    <option value="rsa:2048">RSA-2048</option>
+                    <option value="mlkem:768">ML-KEM-768</option>
+                    <option value="mlkem:1024">ML-KEM-1024</option>
+                  </select>
+                </fieldset>
               </div>
-            </form>
-            <form className="column">
+            </section>
+            <section className="step">
               <h2>Decrypt</h2>
-              <div className="card horizontal-flow">
+              <div className="step-body card">
                 <button id="decryptButton" onClick={() => handleDecrypt()} type="button">
                   decrypt
                 </button>
+                <fieldset className="options">
+                  <legend>Options</legend>
+                  <label htmlFor="rewrapAlgorithm">Rewrap key algorithm</label>{' '}
+                  <select
+                    id="rewrapAlgorithm"
+                    value={rewrapAlgorithm}
+                    onChange={(e) => setRewrapAlgorithm(e.target.value as KasPublicKeyAlgorithm)}
+                  >
+                    <option value="ec:secp256r1">EC P-256</option>
+                    <option value="rsa:2048">RSA-2048</option>
+                    <option value="mlkem:768">ML-KEM-768</option>
+                    <option value="mlkem:1024">ML-KEM-1024</option>
+                  </select>
+                </fieldset>
               </div>
-            </form>
-            {downloadState && <div id="downloadState">{downloadState}</div>}
+            </section>
           </div>
+        )}
+        {(!!downloadState || !!kaoMetadata?.length) && (
+          <section className="step">
+            <h2>Output</h2>
+            <div className="step-body">
+              {downloadState && (
+                <div id="downloadState" className="status">
+                  {downloadState}
+                </div>
+              )}
+              {kaoMetadata?.length ? (
+                <fieldset className="inspector">
+                  <legend>Manifest Inspector</legend>
+                  {/* Label/value rows rather than a wide table: one key access
+                      object is the common case, and this stays readable when the
+                      viewport is too narrow for six columns. */}
+                  <ol id="kaoMetadata" className="kao-list">
+                    {kaoMetadata.map((kao, idx) => (
+                      <li key={idx} id={`kao-row-${idx}`} className="kao">
+                        <h3>Key access object {idx}</h3>
+                        <dl>
+                          <dt>kid</dt>
+                          <dd id={`kao-kid-${idx}`}>{kao.kid}</dd>
+                          <dt>type</dt>
+                          <dd id={`kao-type-${idx}`}>{kao.type}</dd>
+                          <dt>protocol</dt>
+                          <dd id={`kao-protocol-${idx}`}>{kao.protocol}</dd>
+                          {/* Unit is in the label so the value stays a bare number. */}
+                          <dt>wrappedKey bytes</dt>
+                          <dd id={`kao-wrapped-bytes-${idx}`}>{kao.wrappedKeyBytes}</dd>
+                          <dt>kas url</dt>
+                          <dd id={`kao-url-${idx}`}>{kao.url}</dd>
+                        </dl>
+                      </li>
+                    ))}
+                  </ol>
+                </fieldset>
+              ) : null}
+            </div>
+          </section>
         )}
       </div>
     </div>

--- a/web-app/src/App.tsx
+++ b/web-app/src/App.tsx
@@ -280,29 +280,41 @@ function App() {
       });
   }, []);
 
+  // The output panel describes whatever was last encrypted or decrypted, so any
+  // change of source invalidates it. Retire it here rather than in each handler:
+  // url and bytes sources have no `Clear file` button to hang the reset off, and
+  // an inspector left over from the previous file claims something untrue about
+  // the new one.
+  const selectInputSource = (next: InputSource | undefined) => {
+    setInputSource(next);
+    setDownloadState(undefined);
+    setKaoMetadata(undefined);
+    setAlgorithmWarning(undefined);
+  };
+
   const setFileHandler = (event: ChangeEvent<HTMLInputElement>) => {
     const target = event.target as HTMLInputElement;
     if (target.files?.length) {
       const [file] = target.files;
-      setInputSource({ type: 'file', file });
+      selectInputSource({ type: 'file', file });
     } else {
-      setInputSource(undefined);
+      selectInputSource(undefined);
     }
   };
   const setRandomHandler = (event: ChangeEvent<HTMLInputElement>) => {
     const target = event.target as HTMLInputElement;
     if (target.value && target.validity.valid) {
-      setInputSource({ type: 'bytes', length: parseInt(target.value) });
+      selectInputSource({ type: 'bytes', length: parseInt(target.value) });
     } else {
-      setInputSource(undefined);
+      selectInputSource(undefined);
     }
   };
   const setUrlHandler = (event: ChangeEvent<HTMLInputElement>) => {
     const target = event.target as HTMLInputElement;
     if (target.value && target.validity.valid) {
-      setInputSource({ type: 'url', url: new URL(target.value) });
+      selectInputSource({ type: 'url', url: new URL(target.value) });
     } else {
-      setInputSource(undefined);
+      selectInputSource(undefined);
     }
   };
 
@@ -644,18 +656,7 @@ function App() {
                       <div>Size: {new Intl.NumberFormat().format(inputSource.file.size)} bytes</div>
                     </>
                   )}
-                  <button
-                    id="clearFile"
-                    onClick={() => {
-                      setInputSource(undefined);
-                      setDownloadState(undefined);
-                      // The inspector describes the file being cleared, so it has
-                      // to go too; otherwise it lingers over the next selection.
-                      setKaoMetadata(undefined);
-                      setAlgorithmWarning(undefined);
-                    }}
-                    type="button"
-                  >
+                  <button id="clearFile" onClick={() => selectInputSource(undefined)} type="button">
                     Clear file
                   </button>
                 </div>

--- a/web-app/src/App.tsx
+++ b/web-app/src/App.tsx
@@ -27,28 +27,51 @@ async function toFile(
   return stream.pipeTo(fileStream, options);
 }
 
-function decryptedFileName(encryptedFileName: string): string {
-  // Groups: 1 file 'name' bit
-  // 2: original file extension
-  // [non-capture group] - match how safari and chrome insert counters before extension.
-  //    I'm guessing this has some fascinating internationalizations but for now WFM is enough.
-  // 3: TDF container type extension
-  const m = encryptedFileName.match(/^(.+)\.(\w+)(?:-\d+| \(\d+\))?\.(tdf|ztdf)$/);
-  console.log(encryptedFileName, m);
+/**
+ * `mlkem:768` -> `mlkem768`. Colons are legal in a file name but awkward on
+ * Windows and in shell paths, and this matches the KAS kid convention.
+ */
+function algorithmSlug(algorithm: KasPublicKeyAlgorithm): string {
+  return algorithm.replace(':', '');
+}
+
+// Groups: 1 file 'name' bit
+// 2: original file extension
+// 3: the wrap qualifier we appended on encrypt, e.g. `-mlkem768`. Lazy so that a
+//    browser-inserted counter is left to the group below rather than swallowed.
+// [non-capture group] - match how safari and chrome insert counters before extension.
+//    I'm guessing this has some fascinating internationalizations but for now WFM is enough.
+// 4: TDF container type extension
+const ENCRYPTED_FILE_NAME = /^(.+)\.(\w+)((?:-[\w=]+)*?)(?:-\d+| \(\d+\))?\.(tdf|ztdf)$/;
+
+function parseEncryptedFileName(encryptedFileName: string) {
+  const m = encryptedFileName.match(ENCRYPTED_FILE_NAME);
   if (!m) {
     console.warn(`Unable to extract raw file name from ${encryptedFileName}`);
-    return `${encryptedFileName}.decrypted`;
+    return undefined;
   }
-  return `${m[1]}.decrypted.${m[2]}`;
+  return { base: m[1], extension: m[2], wrapQualifier: m[3] };
+}
+
+/**
+ * Keeps the wrap qualifier the encrypt side added and records the mechanism the
+ * client used for the rewrap exchange, so the two post-quantum legs are both
+ * visible in the file name.
+ */
+function decryptedFileName(
+  encryptedFileName: string,
+  rewrapAlgorithm: KasPublicKeyAlgorithm
+): string {
+  const rewrapQualifier = `-rwk-p=${algorithmSlug(rewrapAlgorithm)}`;
+  const parts = parseEncryptedFileName(encryptedFileName);
+  if (!parts) {
+    return `${encryptedFileName}${rewrapQualifier}.decrypted`;
+  }
+  return `${parts.base}${parts.wrapQualifier}${rewrapQualifier}.decrypted.${parts.extension}`;
 }
 
 function decryptedFileExtension(encryptedFileName: string): string {
-  const m = encryptedFileName.match(/^(.+)\.(\w+)\.(tdf|ztdf)$/);
-  if (!m) {
-    console.warn(`Unable to extract raw file name from ${encryptedFileName}`);
-    return `${encryptedFileName}.decrypted`;
-  }
-  return m[2];
+  return parseEncryptedFileName(encryptedFileName)?.extension ?? 'decrypted';
 }
 
 const oidcClient = new OidcClient(config.oidc.host, config.oidc.clientId, 'otdf-sample-web-app');
@@ -434,7 +457,9 @@ function App() {
     setDownloadState('Encrypting...');
     setKaoMetadata(undefined);
     let f: FileSystemFileHandle | undefined;
-    const downloadName = `${inputFileName}.tdf`;
+    // Tag the container with the wrap algorithm so a folder full of demo output
+    // says which encapsulation produced which file.
+    const downloadName = `${inputFileName}-${algorithmSlug(encapAlgorithm)}.tdf`;
     if (sinkType === 'fsapi') {
       f = await getNewFileHandle('tdf', downloadName);
     }
@@ -492,7 +517,7 @@ function App() {
       console.error('decrypt while logged out doesnt work');
       return false;
     }
-    const dfn = decryptedFileName(fileNameFor(inputSource));
+    const dfn = decryptedFileName(fileNameFor(inputSource), rewrapAlgorithm);
     console.log(`Decrypting ${JSON.stringify(inputSource)} to ${sinkType} ${dfn}`);
     // Drop anything left over from a previous encrypt or decrypt so the panel
     // always reflects the file we're reading now.

--- a/web-app/src/App.tsx
+++ b/web-app/src/App.tsx
@@ -7,12 +7,20 @@ import {
   type Chunker,
   type DecoratedStream,
   type KasPublicKeyAlgorithm,
+  type KeyAccessType,
   type Manifest,
   type Source,
   OpenTDF,
 } from '@opentdf/sdk';
 import { type SessionInformation, OidcClient } from './session.js';
 import { config } from './config.js';
+import {
+  actualWrapQualifier,
+  algorithmSlug,
+  decryptedFileExtension,
+  decryptedFileName,
+  expectedKaoType,
+} from './fileNames.js';
 
 async function toFile(
   stream: ReadableStream<Uint8Array>,
@@ -25,53 +33,6 @@ async function toFile(
   });
 
   return stream.pipeTo(fileStream, options);
-}
-
-/**
- * `mlkem:768` -> `mlkem768`. Colons are legal in a file name but awkward on
- * Windows and in shell paths, and this matches the KAS kid convention.
- */
-function algorithmSlug(algorithm: KasPublicKeyAlgorithm): string {
-  return algorithm.replace(':', '');
-}
-
-// Groups: 1 file 'name' bit
-// 2: original file extension
-// 3: the wrap qualifier we appended on encrypt, e.g. `-mlkem768`. Lazy so that a
-//    browser-inserted counter is left to the group below rather than swallowed.
-// [non-capture group] - match how safari and chrome insert counters before extension.
-//    I'm guessing this has some fascinating internationalizations but for now WFM is enough.
-// 4: TDF container type extension
-const ENCRYPTED_FILE_NAME = /^(.+)\.(\w+)((?:-[\w=]+)*?)(?:-\d+| \(\d+\))?\.(tdf|ztdf)$/;
-
-function parseEncryptedFileName(encryptedFileName: string) {
-  const m = encryptedFileName.match(ENCRYPTED_FILE_NAME);
-  if (!m) {
-    console.warn(`Unable to extract raw file name from ${encryptedFileName}`);
-    return undefined;
-  }
-  return { base: m[1], extension: m[2], wrapQualifier: m[3] };
-}
-
-/**
- * Keeps the wrap qualifier the encrypt side added and records the mechanism the
- * client used for the rewrap exchange, so the two post-quantum legs are both
- * visible in the file name.
- */
-function decryptedFileName(
-  encryptedFileName: string,
-  rewrapAlgorithm: KasPublicKeyAlgorithm
-): string {
-  const rewrapQualifier = `-rwk-p=${algorithmSlug(rewrapAlgorithm)}`;
-  const parts = parseEncryptedFileName(encryptedFileName);
-  if (!parts) {
-    return `${encryptedFileName}${rewrapQualifier}.decrypted`;
-  }
-  return `${parts.base}${parts.wrapQualifier}${rewrapQualifier}.decrypted.${parts.extension}`;
-}
-
-function decryptedFileExtension(encryptedFileName: string): string {
-  return parseEncryptedFileName(encryptedFileName)?.extension ?? 'decrypted';
 }
 
 const oidcClient = new OidcClient(config.oidc.host, config.oidc.clientId, 'otdf-sample-web-app');
@@ -160,7 +121,7 @@ function getDecryptReadTuningFromLocation(): DecryptReadTuning {
 
 type KaoMetadata = {
   kid: string;
-  type: string;
+  type: KeyAccessType;
   url: string;
   protocol: string;
   wrappedKeyBytes: number;
@@ -301,6 +262,9 @@ function App() {
   const [encapAlgorithm, setEncapAlgorithm] = useState<KasPublicKeyAlgorithm>('ec:secp256r1');
   const [rewrapAlgorithm, setRewrapAlgorithm] = useState<KasPublicKeyAlgorithm>('rsa:2048');
   const [kaoMetadata, setKaoMetadata] = useState<KaoMetadata[] | undefined>();
+  // Kept out of downloadState because the progress transformers overwrite that
+  // several times a second; a warning parked there would never be read.
+  const [algorithmWarning, setAlgorithmWarning] = useState<string | undefined>();
   const [streamController, setStreamController] = useState<CurrentDataController>();
 
   useEffect(() => {
@@ -456,12 +420,17 @@ function App() {
     });
     setDownloadState('Encrypting...');
     setKaoMetadata(undefined);
+    setAlgorithmWarning(undefined);
     let f: FileSystemFileHandle | undefined;
     // Tag the container with the wrap algorithm so a folder full of demo output
-    // says which encapsulation produced which file.
-    const downloadName = `${inputFileName}-${algorithmSlug(encapAlgorithm)}.tdf`;
+    // says which encapsulation produced which file. This is only the algorithm
+    // we asked for: the Save As picker has to open while the click activation is
+    // still live, which is before the KAS has told us what it actually used. The
+    // download sink corrects the name below; for `fsapi` the user has already
+    // named the file, so there we can only warn.
+    const requestedName = `${inputFileName}-${algorithmSlug(encapAlgorithm)}.tdf`;
     if (sinkType === 'fsapi') {
-      f = await getNewFileHandle('tdf', downloadName);
+      f = await getNewFileHandle('tdf', requestedName);
     }
     const progressTransformers = makeProgressPair(size, 'Encrypt');
 
@@ -478,11 +447,36 @@ function App() {
       return;
     }
     // Surface the key access objects we just wrote, so the wrap algorithm choice
-    // is visible without having to decrypt first. Don't await; this shouldn't
+    // is visible without having to decrypt first. createZTDF attaches an
+    // already-resolved promise, so awaiting it costs a microtask and does not
     // hold up the download.
-    cipherText.manifest
-      ?.then((manifest) => setKaoMetadata(kaoMetadataFrom(manifest)))
-      .catch((e) => console.warn('failed to read manifest after encrypt', e));
+    let downloadName = requestedName;
+    if (!cipherText.manifest) {
+      console.error('encrypt produced no manifest; cannot show key access objects');
+      setAlgorithmWarning('Encrypted, but the SDK returned no manifest to inspect.');
+    } else {
+      try {
+        const kaos = kaoMetadataFrom(await cipherText.manifest);
+        setKaoMetadata(kaos);
+        // What we asked for is not necessarily what wrapped the DEK: fetchKasPubKey
+        // prefers the platform base key and drops the requested algorithm, and the
+        // SDK only console.warns when the two disagree. Name the file after what
+        // actually happened rather than letting it assert something untrue.
+        const [kao] = kaos;
+        if (kao && kao.type !== expectedKaoType(encapAlgorithm)) {
+          downloadName = `${inputFileName}${actualWrapQualifier(kao.type, kao.kid)}.tdf`;
+          setAlgorithmWarning(
+            `Requested ${encapAlgorithm}, but the KAS wrapped with ${kao.type} (kid ${kao.kid}). ` +
+              (sinkType === 'fsapi'
+                ? 'The name you chose does not reflect this.'
+                : `Saved as ${downloadName}.`)
+          );
+        }
+      } catch (e) {
+        console.warn('failed to read manifest after encrypt', e);
+        setAlgorithmWarning(`Encrypted, but could not read the manifest to inspect it: ${e}`);
+      }
+    }
     const cipherTextWithProgress = cipherText.pipeThrough(progressTransformers.writer);
     try {
       switch (sinkType) {
@@ -522,6 +516,7 @@ function App() {
     // Drop anything left over from a previous encrypt or decrypt so the panel
     // always reflects the file we're reading now.
     setKaoMetadata(undefined);
+    setAlgorithmWarning(undefined);
     let f: FileSystemFileHandle | undefined;
     if (sinkType === 'fsapi') {
       f = await getNewFileHandle(decryptedFileExtension(fileNameFor(inputSource)), dfn);
@@ -654,6 +649,10 @@ function App() {
                     onClick={() => {
                       setInputSource(undefined);
                       setDownloadState(undefined);
+                      // The inspector describes the file being cleared, so it has
+                      // to go too; otherwise it lingers over the next selection.
+                      setKaoMetadata(undefined);
+                      setAlgorithmWarning(undefined);
                     }}
                     type="button"
                   >
@@ -798,13 +797,18 @@ function App() {
             </section>
           </div>
         )}
-        {(!!downloadState || !!kaoMetadata?.length) && (
+        {(!!downloadState || !!kaoMetadata?.length || !!algorithmWarning) && (
           <section className="step">
             <h2>Output</h2>
             <div className="step-body">
               {downloadState && (
                 <div id="downloadState" className="status">
                   {downloadState}
+                </div>
+              )}
+              {algorithmWarning && (
+                <div id="algorithmWarning" className="status warning" role="alert">
+                  ⚠️ {algorithmWarning}
                 </div>
               )}
               {kaoMetadata?.length ? (

--- a/web-app/src/fileNames.test.ts
+++ b/web-app/src/fileNames.test.ts
@@ -1,0 +1,259 @@
+import { PUBLIC_KEY_ALGORITHMS } from '@opentdf/sdk';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  actualWrapQualifier,
+  algorithmSlug,
+  decryptedFileExtension,
+  decryptedFileName,
+  expectedKaoType,
+  parseEncryptedFileName,
+} from './fileNames.js';
+
+// The full KasPublicKeyAlgorithm union. Kept explicit rather than imported so
+// that adding a member to the SDK shows up here as a missing case instead of
+// silently widening the table.
+const ALL_ALGORITHMS = [
+  'ec:secp256r1',
+  'ec:secp384r1',
+  'ec:secp521r1',
+  'rsa:2048',
+  'rsa:4096',
+  'mlkem:768',
+  'mlkem:1024',
+] as const;
+
+// ENCRYPTED_FILE_NAME builds its qualifier alternation from PUBLIC_KEY_ALGORITHMS,
+// so the table above has to stay in step with the SDK or the cases below stop
+// covering what the parser actually accepts.
+it('covers every algorithm the SDK exposes', () => {
+  expect([...ALL_ALGORITHMS]).toEqual([...PUBLIC_KEY_ALGORITHMS]);
+});
+
+describe('algorithmSlug', () => {
+  it.each([
+    ['ec:secp256r1', 'ecsecp256r1'],
+    ['rsa:2048', 'rsa2048'],
+    ['mlkem:768', 'mlkem768'],
+    ['mlkem:1024', 'mlkem1024'],
+  ] as const)('%s -> %s', (algorithm, expected) => {
+    expect(algorithmSlug(algorithm)).toBe(expected);
+  });
+
+  // decryptedFileName concatenates the slug into a name that decrypt has to
+  // re-parse, so every slug must be one ENCRYPTED_FILE_NAME's qualifier group
+  // recognises -- including the three the dropdown offers but no test names.
+  it('produces a slug the file name parser can round-trip, for every algorithm', () => {
+    for (const algorithm of ALL_ALGORITHMS) {
+      const slug = algorithmSlug(algorithm);
+      expect(slug, `${algorithm} slug must be qualifier-safe`).toMatch(/^\w+$/);
+      expect(parseEncryptedFileName(`README.md-${slug}.tdf`)).toEqual({
+        base: 'README',
+        extension: 'md',
+        wrapQualifier: `-${slug}`,
+      });
+    }
+  });
+});
+
+describe('expectedKaoType', () => {
+  it.each([
+    ['ec:secp256r1', 'ec-wrapped'],
+    ['ec:secp521r1', 'ec-wrapped'],
+    ['rsa:2048', 'wrapped'],
+    ['rsa:4096', 'wrapped'],
+    ['mlkem:768', 'mlkem-wrapped'],
+    ['mlkem:1024', 'mlkem-wrapped'],
+  ] as const)('%s -> %s', (algorithm, expected) => {
+    expect(expectedKaoType(algorithm)).toBe(expected);
+  });
+});
+
+describe('actualWrapQualifier', () => {
+  it.each([
+    ['wrapped', 'r1', '-kao=rsa-kid=r1'],
+    ['ec-wrapped', 'e1', '-kao=ec-kid=e1'],
+    ['mlkem-wrapped', 'mlkem768', '-kao=mlkem-kid=mlkem768'],
+    ['remote', 'r1', '-kao=remote-kid=r1'],
+    // kaoMetadataFrom substitutes this when the key access object has no kid.
+    // Parens and a space cannot survive as a qualifier, so the kid is dropped
+    // whole rather than scrubbed into something that looks real.
+    ['wrapped', '(no kid)', '-kao=rsa'],
+    ['ec-wrapped', 'kas-1.example', '-kao=ec'],
+    ['wrapped', '', '-kao=rsa'],
+  ] as const)('%s / %s -> %s', (kaoType, kid, expected) => {
+    expect(actualWrapQualifier(kaoType, kid)).toBe(expected);
+  });
+
+  // Same contract as the algorithmSlug round-trip above: whatever we append on
+  // encrypt, decrypt has to be able to read back off the container name.
+  it('produces a qualifier the file name parser can round-trip', () => {
+    for (const kaoType of ['remote', 'wrapped', 'ec-wrapped', 'mlkem-wrapped'] as const) {
+      for (const kid of ['e1', 'r1', 'mlkem768', '(no kid)']) {
+        const qualifier = actualWrapQualifier(kaoType, kid);
+        expect(parseEncryptedFileName(`README.md${qualifier}.tdf`)).toEqual({
+          base: 'README',
+          extension: 'md',
+          wrapQualifier: qualifier,
+        });
+      }
+    }
+  });
+});
+
+describe('parseEncryptedFileName', () => {
+  it.each([
+    // [input, base, extension, wrapQualifier]
+    ['README.md.tdf', 'README', 'md', ''],
+    ['README.md.ztdf', 'README', 'md', ''],
+    ['README.md-mlkem768.tdf', 'README', 'md', '-mlkem768'],
+    ['README.md-ecsecp256r1.tdf', 'README', 'md', '-ecsecp256r1'],
+    ['README.md-mlkem768.ztdf', 'README', 'md', '-mlkem768'],
+    // The mismatch qualifier, for when the KAS ignored the algorithm we asked
+    // for. Both tokens carry an `=`, which the extension group cannot match.
+    ['README.md-kao=rsa-kid=r1.tdf', 'README', 'md', '-kao=rsa-kid=r1'],
+    ['README.md-kao=ec-kid=e1.tdf', 'README', 'md', '-kao=ec-kid=e1'],
+    ['README.md-kao=rsa.tdf', 'README', 'md', '-kao=rsa'],
+    ['archive.tar.gz-kao=ec-kid=e1.ztdf', 'archive.tar', 'gz', '-kao=ec-kid=e1'],
+    ['file.foo-bar-kao=ec-kid=e1.tdf', 'file', 'foo-bar', '-kao=ec-kid=e1'],
+    // Chrome and Safari insert a counter when the name is already taken. It
+    // must land in the counter group, not be mistaken for a wrap qualifier.
+    ['README.md-mlkem768-1.tdf', 'README', 'md', '-mlkem768'],
+    ['README.md-mlkem768 (1).tdf', 'README', 'md', '-mlkem768'],
+    ['README.md-kao=ec-kid=e1 (1).tdf', 'README', 'md', '-kao=ec-kid=e1'],
+    ['README.md-kao=ec-kid=e1-1.tdf', 'README', 'md', '-kao=ec-kid=e1'],
+    ['README.md-1.tdf', 'README', 'md', ''],
+    ['README.md (2).tdf', 'README', 'md', ''],
+    // Only the last dot-segment before the qualifier counts as the extension.
+    ['archive.tar.gz-mlkem768.tdf', 'archive.tar', 'gz', '-mlkem768'],
+    ['my file.md-mlkem768.tdf', 'my file', 'md', '-mlkem768'],
+    // A hyphen in the extension is not a wrap qualifier. Only slugs we emit are.
+    ['file.foo-bar-mlkem768.tdf', 'file', 'foo-bar', '-mlkem768'],
+    ['file.foo-bar.tdf', 'file', 'foo-bar', ''],
+    // A slug-shaped extension is read as the extension, because the qualifier
+    // group only gets what the extension leaves and the extension needs at least
+    // one character. `file.mlkem768` is the likelier source name anyway.
+    ['file.mlkem768.tdf', 'file', 'mlkem768', ''],
+    // Re-encrypting a decrypted file: the `=` in the rewrap qualifier survives.
+    [
+      'README-mlkem768-rwk-p=mlkem1024.decrypted.md-mlkem768.tdf',
+      'README-mlkem768-rwk-p=mlkem1024.decrypted',
+      'md',
+      '-mlkem768',
+    ],
+  ])('parses %s', (input, base, extension, wrapQualifier) => {
+    expect(parseEncryptedFileName(input)).toEqual({ base, extension, wrapQualifier });
+  });
+
+  it.each([
+    ['README.md', 'no container extension'],
+    ['Makefile-mlkem768.tdf', 'no inner extension to recover'],
+    ['sample.tdf', 'no inner extension to recover'],
+    ['README.md-mlkem768.TDF', 'container extension is matched case-sensitively'],
+    ['random-bytes-1048576-bytes-mlkem768.tdf', "the app's own random-source name"],
+  ])('returns undefined for %s (%s)', (input) => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(parseEncryptedFileName(input)).toBeUndefined();
+    expect(warn).toHaveBeenCalledOnce();
+    warn.mockRestore();
+  });
+
+  // Documents a known limitation rather than endorsing it: the counter
+  // alternative claims an all-digit token that the qualifier group has already
+  // declined. Unreachable, since every slug in PUBLIC_KEY_ALGORITHMS starts with
+  // a letter, and the assertion above keeps that true.
+  it('mistakes an all-digit wrap qualifier for a browser counter', () => {
+    expect(parseEncryptedFileName('README.md-2048.tdf')).toEqual({
+      base: 'README',
+      extension: 'md',
+      wrapQualifier: '',
+    });
+  });
+
+  // Why actualWrapQualifier exists. A bare kid is not an algorithm slug, so the
+  // extension group -- which allows hyphens -- swallows it, and the decrypted
+  // name inherits the damage. Pinned so the reason survives the fix.
+  it.each(['e1', 'r1'])('swallows a bare `%s` kid into the extension', (kid) => {
+    expect(parseEncryptedFileName(`README.md-${kid}.tdf`)).toEqual({
+      base: 'README',
+      extension: `md-${kid}`,
+      wrapQualifier: '',
+    });
+  });
+});
+
+describe('decryptedFileName', () => {
+  it('carries the wrap qualifier through and appends the rewrap mechanism', () => {
+    expect(decryptedFileName('README.md-mlkem768.tdf', 'mlkem:1024')).toBe(
+      'README-mlkem768-rwk-p=mlkem1024.decrypted.md'
+    );
+  });
+
+  it('records the rewrap leg even when the container carries no wrap qualifier', () => {
+    expect(decryptedFileName('README.md.tdf', 'rsa:2048')).toBe(
+      'README-rwk-p=rsa2048.decrypted.md'
+    );
+  });
+
+  // The reviewer's regression case: an EC or RSA kid in the name must not cost
+  // the original extension. `README.md-r1.tdf` used to decrypt to
+  // `README-rwk-p=mlkem768.decrypted.md-r1`.
+  it.each([
+    ['README.md-kao=rsa-kid=r1.tdf', 'README-kao=rsa-kid=r1-rwk-p=mlkem768.decrypted.md'],
+    ['README.md-kao=ec-kid=e1.tdf', 'README-kao=ec-kid=e1-rwk-p=mlkem768.decrypted.md'],
+    ['README.md-kao=rsa.tdf', 'README-kao=rsa-rwk-p=mlkem768.decrypted.md'],
+  ])('carries the mismatch qualifier through and keeps the extension: %s', (input, expected) => {
+    expect(decryptedFileName(input, 'mlkem:768')).toBe(expected);
+  });
+
+  it('keeps a hyphenated extension whole', () => {
+    expect(decryptedFileName('file.foo-bar-mlkem768.tdf', 'mlkem:1024')).toBe(
+      'file-mlkem768-rwk-p=mlkem1024.decrypted.foo-bar'
+    );
+  });
+
+  it('drops a browser-inserted counter rather than treating it as a qualifier', () => {
+    expect(decryptedFileName('README.md-mlkem768 (1).tdf', 'rsa:2048')).toBe(
+      'README-mlkem768-rwk-p=rsa2048.decrypted.md'
+    );
+  });
+
+  it('falls back to suffixing the whole name when it cannot be parsed', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(decryptedFileName('sample.tdf', 'mlkem:768')).toBe(
+      'sample.tdf-rwk-p=mlkem768.decrypted'
+    );
+    warn.mockRestore();
+  });
+});
+
+describe('decryptedFileExtension', () => {
+  it('recovers the original extension', () => {
+    expect(decryptedFileExtension('README.md-mlkem768.tdf')).toBe('md');
+  });
+
+  it('recovers the original extension past a mismatch qualifier', () => {
+    expect(decryptedFileExtension('README.md-kao=rsa-kid=r1.tdf')).toBe('md');
+  });
+
+  // The picker's accept filter has to match the name decryptedFileName offers
+  // for the same input, or the Save As dialog rejects its own suggestion.
+  it.each([
+    'README.md-mlkem768.tdf',
+    'README.md.tdf',
+    'sample.tdf',
+    'Makefile-mlkem768.tdf',
+    'README.md-kao=rsa-kid=r1.tdf',
+    'README.md-kao=ec.tdf',
+  ])('agrees with the suggested name for %s', (input) => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const suggested = decryptedFileName(input, 'rsa:2048');
+    expect(suggested.endsWith(`.${decryptedFileExtension(input)}`)).toBe(true);
+    warn.mockRestore();
+  });
+
+  it('falls back to `decrypted`, matching the unparseable-name suffix', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(decryptedFileExtension('sample.tdf')).toBe('decrypted');
+    warn.mockRestore();
+  });
+});

--- a/web-app/src/fileNames.ts
+++ b/web-app/src/fileNames.ts
@@ -1,0 +1,129 @@
+import {
+  type KasPublicKeyAlgorithm,
+  type KeyAccessType,
+  PUBLIC_KEY_ALGORITHMS,
+} from '@opentdf/sdk';
+
+/**
+ * `mlkem:768` -> `mlkem768`. Colons are legal in a file name but awkward on
+ * Windows and in shell paths. For ML-KEM the slug happens to equal the KAS kid
+ * (`mlkem:768` -> kid `mlkem768`); EC and RSA kids are unrelated (`e1`, `r1`).
+ *
+ * Every member of KasPublicKeyAlgorithm has exactly one colon and is otherwise
+ * alphanumeric, so a non-global replace is enough today; a hybrid identifier
+ * such as `ec:secp256r1+mlkem:768` would need `replaceAll`.
+ */
+export function algorithmSlug(algorithm: KasPublicKeyAlgorithm): string {
+  return algorithm.replace(':', '');
+}
+
+/**
+ * The key access object type the KAS should produce for a requested wrap
+ * algorithm. Used to detect the case where it produced something else.
+ */
+export function expectedKaoType(algorithm: KasPublicKeyAlgorithm): KeyAccessType {
+  if (algorithm.startsWith('mlkem:')) {
+    return 'mlkem-wrapped';
+  }
+  return algorithm.startsWith('ec:') ? 'ec-wrapped' : 'wrapped';
+}
+
+/**
+ * The coarse inverse of {@link expectedKaoType}. Deliberately coarse: a key
+ * access type names the family but not the curve or modulus size, so there is
+ * no honest way to recover a full algorithm slug from one.
+ */
+const KAO_TYPE_SLUG: Record<KeyAccessType, string> = {
+  remote: 'remote',
+  wrapped: 'rsa',
+  'ec-wrapped': 'ec',
+  'mlkem-wrapped': 'mlkem',
+};
+
+/**
+ * Names what actually wrapped the DEK, for the case where that is not what we
+ * asked for. Never emit a bare kid here: EC and RSA kids (`e1`, `r1`) are not
+ * algorithm slugs, so `README.md-e1.tdf` parses with `md-e1` as its extension
+ * and decrypt then hands back `README-rwk-p=….decrypted.md-e1`.
+ *
+ * The kid is dropped, not mangled, when it holds anything a qualifier cannot
+ * carry -- including the `(no kid)` placeholder the caller substitutes for an
+ * absent one. A half-scrubbed kid would be worse than none: the panel shows the
+ * real value either way, and a name should not claim a kid nobody can look up.
+ */
+export function actualWrapQualifier(kaoType: KeyAccessType, kid: string): string {
+  const kidToken = /^\w+$/.test(kid) ? `-kid=${kid}` : '';
+  return `-kao=${KAO_TYPE_SLUG[kaoType]}${kidToken}`;
+}
+
+// Longest first so a slug that is a prefix of another cannot win and strand the
+// rest of the name. Nothing in the current list overlaps; this is insurance for
+// whatever gets added next.
+const ALGORITHM_SLUGS = PUBLIC_KEY_ALGORITHMS.map(algorithmSlug).sort(
+  (a, b) => b.length - a.length
+);
+
+// Groups: 1 file 'name' bit
+// 2: original file extension. Lazy, and allows `-`, so that a hyphenated
+//    extension is kept whole: without both, `file.foo-bar-mlkem768.tdf` parses as
+//    extension `foo` and the decrypted name silently loses the `-bar`.
+// 3: the wrap qualifier we appended on encrypt, e.g. `-mlkem768`, or the
+//    `-kao=…-kid=…` pair {@link actualWrapQualifier} emits when the KAS did not
+//    use the algorithm we asked for. Restricted to tokens we actually emit,
+//    which is what lets group 2 tell `-bar` (part of the extension) apart from
+//    `-mlkem768` (not). The `kao=`/`kid=` tokens need no such help: group 2
+//    cannot match an `=`, so they can never be read as part of an extension.
+//    Repetition covers the pair; a `.tdf` name never carries a wrap qualifier
+//    twice, because the rewrap qualifier decrypt appends lands on a
+//    `.decrypted.<ext>` name and so ends up in group 1.
+// [non-capture group] - match how safari and chrome insert counters before extension.
+//    I'm guessing this has some fascinating internationalizations but for now WFM is enough.
+// 4: TDF container type extension
+const QUALIFIER_TOKENS = [...ALGORITHM_SLUGS, 'kao=\\w+', 'kid=\\w+'];
+
+export const ENCRYPTED_FILE_NAME = new RegExp(
+  `^(.+)\\.([\\w-]+?)((?:-(?:${QUALIFIER_TOKENS.join('|')}))*)(?:-\\d+| \\(\\d+\\))?\\.(tdf|ztdf)$`
+);
+
+export type ParsedEncryptedFileName = {
+  base: string;
+  extension: string;
+  /** Empty, or one or more `-token` segments *including* the leading `-`. */
+  wrapQualifier: string;
+};
+
+export function parseEncryptedFileName(
+  encryptedFileName: string
+): ParsedEncryptedFileName | undefined {
+  const m = encryptedFileName.match(ENCRYPTED_FILE_NAME);
+  if (!m) {
+    console.warn(`Unable to extract raw file name from ${encryptedFileName}`);
+    return undefined;
+  }
+  return { base: m[1], extension: m[2], wrapQualifier: m[3] };
+}
+
+/**
+ * Keeps the wrap qualifier the encrypt side added and records the mechanism the
+ * client used for the rewrap exchange, so the two post-quantum legs are both
+ * visible in the file name.
+ */
+export function decryptedFileName(
+  encryptedFileName: string,
+  rewrapAlgorithm: KasPublicKeyAlgorithm
+): string {
+  const rewrapQualifier = `-rwk-p=${algorithmSlug(rewrapAlgorithm)}`;
+  const parts = parseEncryptedFileName(encryptedFileName);
+  if (!parts) {
+    return `${encryptedFileName}${rewrapQualifier}.decrypted`;
+  }
+  return `${parts.base}${parts.wrapQualifier}${rewrapQualifier}.decrypted.${parts.extension}`;
+}
+
+/**
+ * The extension to offer the Save As picker. Falls back to `decrypted`, which
+ * matches the suffix {@link decryptedFileName} produces on the same input.
+ */
+export function decryptedFileExtension(encryptedFileName: string): string {
+  return parseEncryptedFileName(encryptedFileName)?.extension ?? 'decrypted';
+}

--- a/web-app/tests/tests/roundtrip.spec.ts
+++ b/web-app/tests/tests/roundtrip.spec.ts
@@ -168,6 +168,25 @@ test('download names record both key wrap legs', async ({ page }) => {
   expect(text).toContain('try encrypting some of your own files');
 });
 
+test('changing the source retires the previous output', async ({ page }) => {
+  await authorize(page);
+  // Random bytes rather than a url source: this needs no static server, and the
+  // `Clear file` button that used to be the only reset path is not rendered for
+  // a non-file source, which is exactly the hole being covered.
+  await page.locator('#noneSink').click();
+  await page.locator('#randomSelector').fill('1024');
+  await page.locator('#encryptButton').click();
+
+  await expect(page.locator('#downloadState')).toContainText('Complete');
+  await expect(page.locator('#kaoMetadata')).toBeVisible();
+
+  await page.locator('#randomSelector').fill('2048');
+  // Nothing has been encrypted from the new source, so a status or an inspector
+  // here would be describing the previous one.
+  await expect(page.locator('#downloadState')).toBeHidden();
+  await expect(page.locator('#kaoMetadata')).toBeHidden();
+});
+
 test('Remote Source Streaming', async ({ page }) => {
   const server = await serve('.', 8086);
 

--- a/web-app/tests/tests/roundtrip.spec.ts
+++ b/web-app/tests/tests/roundtrip.spec.ts
@@ -97,6 +97,11 @@ for (const algorithm of ['mlkem:768', 'mlkem:1024'] as const) {
     await expect(page.locator('#kao-wrapped-bytes-0')).toHaveText(String(expectedWrappedKeyBytes));
 
     await page.locator('#clearFile').click();
+    // Clearing the file clears the inspector with it. Without this the decrypt
+    // assertions below could be satisfied by leftover encrypt-side state: both
+    // legs read the same manifest, so they expect identical values.
+    await expect(page.locator('#kaoMetadata')).toBeHidden();
+
     await loadFile(page, cipherTextPath);
     const plainDownloadPromise = page.waitForEvent('download');
     await page.locator('#fileSink').click();
@@ -112,8 +117,8 @@ for (const algorithm of ['mlkem:768', 'mlkem:1024'] as const) {
       'try encrypting some of your own files'
     );
 
-    // Decrypt clears the panel and repopulates it from the manifest it just
-    // read, so these assertions cannot pass on leftover encrypt-side state.
+    // Repopulated by the decrypt-side read. The panel was asserted empty after
+    // #clearFile above, so these cannot be the encrypt-side values lingering.
     await expect(page.locator('#kao-kid-0')).toHaveText(expectedKid);
     await expect(page.locator('#kao-type-0')).toHaveText('mlkem-wrapped');
     await expect(page.locator('#kao-wrapped-bytes-0')).toHaveText(String(expectedWrappedKeyBytes));
@@ -136,7 +141,8 @@ test('download names record both key wrap legs', async ({ page }) => {
   }
 
   // Re-upload under the name encrypt suggested. The other tests hand back
-  // playwright's temp uuid, which can't exercise the name parser at all.
+  // playwright's temp uuid, which has no `.tdf` suffix, so they only ever reach
+  // the parser's no-match fallback and never its successful-parse branch.
   const staged = test.info().outputPath(download.suggestedFilename());
   fs.copyFileSync(cipherTextPath, staged);
 
@@ -150,6 +156,16 @@ test('download names record both key wrap legs', async ({ page }) => {
   const download2 = await plainDownloadPromise;
   // Wrap qualifier is carried through; the rewrap mechanism is appended.
   expect(download2.suggestedFilename()).toBe('README-mlkem768-rwk-p=mlkem1024.decrypted.md');
+
+  // The download event fires when the stream opens, not when it finishes, so the
+  // name alone would still be asserted had the mlkem:768 -> mlkem:1024 rewrap
+  // failed partway. Read the bytes back to pin that the exchange completed.
+  const plainTextPath = await download2.path();
+  if (!plainTextPath) {
+    throw new Error();
+  }
+  const text = await readFile(plainTextPath, 'utf8');
+  expect(text).toContain('try encrypting some of your own files');
 });
 
 test('Remote Source Streaming', async ({ page }) => {

--- a/web-app/tests/tests/roundtrip.spec.ts
+++ b/web-app/tests/tests/roundtrip.spec.ts
@@ -71,7 +71,10 @@ for (const algorithm of ['mlkem:768', 'mlkem:1024'] as const) {
 
     await authorize(page);
     await loadFile(page, 'README.md');
+    // Both legs post-quantum: the KAO wrap on encrypt, and the client's
+    // ephemeral key for the rewrap exchange on decrypt.
     await page.locator('#encapAlgorithm').selectOption(algorithm);
+    await page.locator('#rewrapAlgorithm').selectOption(algorithm);
 
     const downloadPromise = page.waitForEvent('download');
     await page.locator('#fileSink').click();
@@ -83,6 +86,12 @@ for (const algorithm of ['mlkem:768', 'mlkem:1024'] as const) {
     if (!cipherTextPath) {
       throw new Error();
     }
+
+    // The inspector is populated straight off the encrypt manifest, so the
+    // chosen wrap algorithm is observable without decrypting first.
+    await expect(page.locator('#kao-kid-0')).toHaveText(expectedKid);
+    await expect(page.locator('#kao-type-0')).toHaveText('mlkem-wrapped');
+    await expect(page.locator('#kao-wrapped-bytes-0')).toHaveText(String(expectedWrappedKeyBytes));
 
     await page.locator('#clearFile').click();
     await loadFile(page, cipherTextPath);
@@ -100,8 +109,8 @@ for (const algorithm of ['mlkem:768', 'mlkem:1024'] as const) {
       'try encrypting some of your own files'
     );
 
-    // Manifest inspector should display the expected ML-KEM kid (mlkem768/1024)
-    // populated during the decrypt flow above.
+    // Decrypt clears the panel and repopulates it from the manifest it just
+    // read, so these assertions cannot pass on leftover encrypt-side state.
     await expect(page.locator('#kao-kid-0')).toHaveText(expectedKid);
     await expect(page.locator('#kao-type-0')).toHaveText('mlkem-wrapped');
     await expect(page.locator('#kao-wrapped-bytes-0')).toHaveText(String(expectedWrappedKeyBytes));

--- a/web-app/tests/tests/roundtrip.spec.ts
+++ b/web-app/tests/tests/roundtrip.spec.ts
@@ -34,7 +34,8 @@ test('roundtrip ztdf', async ({ page }) => {
   await page.locator('#fileSink').click();
   await page.locator('#encryptButton').click();
   const download = await downloadPromise;
-  expect(download.suggestedFilename()).toContain('README.md.');
+  // Encrypt tags the container with the default wrap algorithm.
+  expect(download.suggestedFilename()).toContain('README.md-ecsecp256r1');
   const cipherTextPath = await download.path();
   expect(cipherTextPath).toBeTruthy();
   if (!cipherTextPath) {
@@ -80,7 +81,9 @@ for (const algorithm of ['mlkem:768', 'mlkem:1024'] as const) {
     await page.locator('#fileSink').click();
     await page.locator('#encryptButton').click();
     const download = await downloadPromise;
-    expect(download.suggestedFilename()).toContain('README.md.');
+    // The wrap qualifier is the algorithm token without its colon, which for
+    // ML-KEM is also the KAS kid.
+    expect(download.suggestedFilename()).toContain(`README.md-${expectedKid}`);
     const cipherTextPath = await download.path();
     expect(cipherTextPath).toBeTruthy();
     if (!cipherTextPath) {
@@ -117,6 +120,38 @@ for (const algorithm of ['mlkem:768', 'mlkem:1024'] as const) {
   });
 }
 
+test('download names record both key wrap legs', async ({ page }) => {
+  await authorize(page);
+  await loadFile(page, 'README.md');
+  await page.locator('#encapAlgorithm').selectOption('mlkem:768');
+
+  const downloadPromise = page.waitForEvent('download');
+  await page.locator('#fileSink').click();
+  await page.locator('#encryptButton').click();
+  const download = await downloadPromise;
+  expect(download.suggestedFilename()).toBe('README.md-mlkem768.tdf');
+  const cipherTextPath = await download.path();
+  if (!cipherTextPath) {
+    throw new Error();
+  }
+
+  // Re-upload under the name encrypt suggested. The other tests hand back
+  // playwright's temp uuid, which can't exercise the name parser at all.
+  const staged = test.info().outputPath(download.suggestedFilename());
+  fs.copyFileSync(cipherTextPath, staged);
+
+  await page.locator('#clearFile').click();
+  await loadFile(page, staged);
+  await page.locator('#rewrapAlgorithm').selectOption('mlkem:1024');
+
+  const plainDownloadPromise = page.waitForEvent('download');
+  await page.locator('#fileSink').click();
+  await page.locator('#decryptButton').click();
+  const download2 = await plainDownloadPromise;
+  // Wrap qualifier is carried through; the rewrap mechanism is appended.
+  expect(download2.suggestedFilename()).toBe('README-mlkem768-rwk-p=mlkem1024.decrypted.md');
+});
+
 test('Remote Source Streaming', async ({ page }) => {
   const server = await serve('.', 8086);
 
@@ -130,7 +165,7 @@ test('Remote Source Streaming', async ({ page }) => {
 
     const download = await downloadPromise;
     const cipherTextPath = await download.path();
-    expect(download.suggestedFilename()).toContain('README.md.');
+    expect(download.suggestedFilename()).toContain('README.md-ecsecp256r1');
     expect(cipherTextPath).toBeTruthy();
     if (!cipherTextPath) {
       throw new Error();


### PR DESCRIPTION
## What

Makes the ML-KEM key-wrap work from DSPX-3229 legible in the browser sample app, so it can be
demonstrated (and recorded) end to end. No `lib/` changes — this is all `web-app/`.

Three commits:

1. **`feat(main)`: surface wrap and rewrap algorithm choice.** The Manifest Inspector only
   populated on decrypt, so choosing ML-KEM and hitting Encrypt left nothing on screen to show it
   worked. `createZTDF` returns a `DecoratedStream` whose `manifest` promise is already resolved,
   so the encrypt-side inspector is free — no re-parse of the output. Also adds a **rewrap key
   algorithm** selector: `ReadOptions.wrappingKeyAlgorithm` picks the client's ephemeral keypair
   for the rewrap exchange, and left unset it falls through to RSA-2048. Without a control, half
   the quantum-safe story — the DEK's journey *back* from the KAS — stays classical and invisible.

   Also adds `.github/workflows/roundtrip/.gitignore`. The root one anchors `/platform` and
   `/*.pem` to the repo root, so local backend bring-up artifacts (the platform symlink, generated
   KAS private keys, the Keycloak CLI zip) would otherwise be snapshotted into the working copy.

2. **`style(main)`: restructure the layout for narrow displays.** The page read as one wide row of
   unrelated fieldsets, and the inspector was a six-column table that wrapped into itself below
   about a laptop width. Now: vertical is flow, horizontal is detail.

   ```
   source + sink  ->  encrypt | decrypt  ->  output + manifest
   ```

   Each action carries the algorithm that affects it, so the wrap selector sits with Encrypt and
   the rewrap selector with Decrypt. Encrypt and decrypt pair up on one row when there's room and
   stack when there isn't. Inspector table becomes label/value rows per KAO.

3. **`feat(main)`: tag download names with the wrap and rewrap mechanisms.**

   | Step | Before | After |
   |---|---|---|
   | Encrypt (`ec:secp256r1`) | `README.md.tdf` | `README.md-ecsecp256r1.tdf` |
   | Encrypt (`mlkem:768`) | `README.md.tdf` | `README.md-mlkem768.tdf` |
   | Decrypt (rewrap `mlkem:1024`) | `README.decrypted.md` | `README-mlkem768-rwk-p=mlkem1024.decrypted.md` |

   A folder of demo output now says which encapsulation produced which file, on both legs.

## Why

`mlkem:768` / `mlkem:1024` are available today but not yet the default. The demo needs to make two
things concrete that were previously invisible: that the KAO wrap really is post-quantum (visible
`type: mlkem-wrapped`, `kid`, and the 1158 / 1638-byte `wrappedKey`), and that the rewrap leg is a
*separate* choice most people miss.

## How to test

Bring up the roundtrip harness backend (see `.github/workflows/roundtrip/`), then:

```sh
cd web-app/tests && npx playwright test --reporter=line --workers=1
```

18 passed locally (3 browsers x 6 tests). `--workers=1` sidesteps a **pre-existing** race in
`Remote Source Streaming`: `static-server.js` binds port 8086 with no EADDRINUSE handling and all
three browser projects share `tests/README.md.tdf`. Confirmed pre-existing by stashing these
changes and reproducing 3/3 failures on the parent commit.

Test changes:
- The ML-KEM loop now asserts `#kao-kid-0` / `#kao-type-0` / `#kao-wrapped-bytes-0` immediately
  after Encrypt (before any decrypt), and drives `#rewrapAlgorithm` so the PQ rewrap leg is
  covered.
- New `download names record both key wrap legs` re-uploads the file *under the name encrypt
  suggested*. The other tests hand back Playwright's temp UUID, so the filename parser's happy
  path was never actually exercised — only its fallback branch.

Also `npm run lint`, `npm test` (Vitest), and `tsc --noEmit` clean in `web-app`.

## Risk

Low, and confined to the sample app. No `lib/` or `cli/` changes, no change to the TDF container,
policy model, or KAS protocol shape. The one behavioural change users will notice is the download
filenames.

Note the decrypt name keeps the existing `.decrypted` infix rather than dropping it, since it's
what distinguishes output from input in the same folder.

## Screenshots

Wide:
<img width="986" height="898" alt="image" src="https://github.com/user-attachments/assets/036515d4-b93b-4bb1-be08-87c132270030" />

Narrow: 

<img width="750" height="1440" alt="image" src="https://github.com/user-attachments/assets/134b6fe8-251f-49d0-80d8-65009e6fad43" />

<!-- Layout changed; attach before/after at desktop and phone widths before merging. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added separate encryption and rewrap algorithm controls.
  * Downloaded files now include applicable algorithm details in their filenames.
  * Added a Manifest Inspector displaying key access metadata after encryption and decryption.
  * Improved responsive layouts for workflows, cards, status elements, and action sections.

* **Bug Fixes**
  * Switching input sources now clears previous downloads, metadata, and warnings.
  * Improved filename handling and warnings when selected and actual algorithms differ.

* **Tests**
  * Expanded coverage for filenames, metadata inspection, rewrap scenarios, and input-source changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->