### PR TITLE
fix(sdk): zip64/APPNOTE conformance in the TDF3 zip reader and writer (DSPX-4591)

### DIFF
--- a/lib/tdf3/src/utils/zip-reader.ts
+++ b/lib/tdf3/src/utils/zip-reader.ts
@@ -3,12 +3,51 @@ import { type Chunker } from '../../../src/seekable.js';
 import { Manifest } from '../models/index.js';
 import { readUInt32LE, readUInt16LE, copyUint8Arr, buffToString } from './index.js';
 
-// TODO: Better document what these constants are
-// TODO: Document each function please
+// Signatures and fixed record sizes from PKWARE APPNOTE.TXT sections 4.3.12-4.3.16.
+/** Central file header signature (APPNOTE 4.3.12). */
 const CD_SIGNATURE = 0x02014b50;
+/** End of central directory record signature (APPNOTE 4.3.16). */
+const EOCDR_SIGNATURE = 0x06054b50;
+/** ZIP64 end of central directory record signature (APPNOTE 4.3.14). */
+const ZIP64_EOCDR_SIGNATURE = 0x06064b50;
+/** ZIP64 end of central directory locator signature (APPNOTE 4.3.15). */
+const ZIP64_EOCDL_SIGNATURE = 0x07064b50;
+
+/** Size of a central file header, excluding name, extra field and comment. */
 const CENTRAL_DIRECTORY_RECORD_FIXED_SIZE = 46;
+/** Size of a local file header, excluding name and extra field. */
 const LOCAL_FILE_HEADER_FIXED_SIZE = 30;
-const VERSION_NEEDED_TO_EXTRACT_ZIP64 = 45;
+/** Size of an end of central directory record, excluding the archive comment. */
+const END_OF_CENTRAL_DIRECTORY_RECORD_SIZE = 22;
+/** Size of a ZIP64 end of central directory locator. Fixed length. */
+const ZIP64_END_OF_CENTRAL_DIRECTORY_LOCATOR_SIZE = 20;
+/** Bytes of the ZIP64 end of central directory record that we read and rely on. */
+const ZIP64_END_OF_CENTRAL_DIRECTORY_RECORD_SIZE = 56;
+
+/** The archive comment length field is 2 bytes, so a comment is at most 64 KiB. */
+const MAX_ARCHIVE_COMMENT_SIZE = 0xffff;
+/**
+ * Enough bytes to always contain the EOCD record, its (optional) ZIP64 locator,
+ * and a maximum length archive comment.
+ */
+const MAX_EOCDR_SEARCH_SIZE =
+  END_OF_CENTRAL_DIRECTORY_RECORD_SIZE +
+  MAX_ARCHIVE_COMMENT_SIZE +
+  ZIP64_END_OF_CENTRAL_DIRECTORY_LOCATOR_SIZE;
+/**
+ * First guess at how much of the tail to read. TDF containers are written without
+ * an archive comment, so the EOCD is the last 22 bytes and one small read suffices.
+ * If the EOCD is not in here we fall back to {@link MAX_EOCDR_SEARCH_SIZE}.
+ */
+const INITIAL_EOCDR_SEARCH_SIZE = 1024;
+
+/**
+ * Sanity bound on the central directory we are willing to buffer. At 46 bytes per
+ * record this still allows for hundreds of thousands of entries, while keeping a
+ * hostile or corrupt EOCD from asking us to allocate the declared 4 GiB.
+ */
+const MAX_CENTRAL_DIRECTORY_SIZE = 16 * 1024 * 1024;
+
 const manifestMaxSize = 1024 * 1024 * 10; // 10 MB
 
 const cp437 =
@@ -54,6 +93,22 @@ export type CentralDirectoryVariableLengthItems = {
 };
 
 /**
+ * The parts of the end of central directory record (APPNOTE 4.3.16), with the
+ * ZIP64 end of central directory record (APPNOTE 4.3.14) already applied where
+ * the 32 bit record carried a sentinel value.
+ */
+export type EndOfCentralDirectory = {
+  /** Total number of central directory records. */
+  entryCount: number;
+  /** Size in bytes of the central directory. */
+  centralDirectorySize: number;
+  /** Offset of the first central directory record from the start of the archive. */
+  centralDirectoryOffset: number;
+  /** True if the values above were read from a ZIP64 end of central directory record. */
+  zip64: boolean;
+};
+
+/**
  *
  * ZipReader -
  *
@@ -69,20 +124,116 @@ export class ZipReader {
 
   /**
    * Utility function to get the centralDirectory for the zip file.
-   * It reads the end of the file to find it.
+   *
+   * Reads the end of central directory record (following the ZIP64 locator when
+   * the EOCD carries a sentinel), then walks exactly the declared number of
+   * records starting at the declared central directory offset.
+   *
    * @return The central directory represented as an object
    */
   async getCentralDirectory(): Promise<CentralDirectory[]> {
-    const chunk = await this.getChunk(-1000);
-    // TODO: Does this need to be tuned??!?
-    // Slice off the EOCDR (End of Central Directory Record) part of the buffer so we can figure out the CD size
-    const cdBuffers = this.getCDBuffers(chunk);
+    const eocd = await this.getEndOfCentralDirectory();
+    const cdChunk = await this.getChunk(
+      eocd.centralDirectoryOffset,
+      eocd.centralDirectoryOffset + eocd.centralDirectorySize
+    );
+    if (cdChunk.length !== eocd.centralDirectorySize) {
+      throw new InvalidFileError(
+        `central directory truncated: expected [${eocd.centralDirectorySize}] bytes at [${eocd.centralDirectoryOffset}], read [${cdChunk.length}]`
+      );
+    }
 
-    const cdParsedBuffers = cdBuffers.map(parseCDBuffer);
+    const cdParsedBuffers = this.getCDBuffers(cdChunk, eocd.entryCount).map(parseCDBuffer);
     for (const buffer of cdParsedBuffers) {
       await this.adjustHeaders(buffer);
     }
     return cdParsedBuffers;
+  }
+
+  /**
+   * Locates and parses the end of central directory record, resolving it against
+   * the ZIP64 end of central directory record when any of the three EOCD fields
+   * carries its sentinel value (APPNOTE 4.3.14 - 4.3.16).
+   */
+  async getEndOfCentralDirectory(): Promise<EndOfCentralDirectory> {
+    let tail = await this.getChunk(-INITIAL_EOCDR_SEARCH_SIZE);
+    let eocdrOffset = findEndOfCentralDirectoryRecord(tail);
+    if (eocdrOffset < 0 && tail.length >= INITIAL_EOCDR_SEARCH_SIZE) {
+      // The archive may carry a comment of up to 64 KiB; widen the search once.
+      tail = await this.getChunk(-MAX_EOCDR_SEARCH_SIZE);
+      eocdrOffset = findEndOfCentralDirectoryRecord(tail);
+    }
+    if (eocdrOffset < 0) {
+      throw new InvalidFileError('unable to find end of central directory record');
+    }
+
+    // 8 - total number of entries in the central directory on this disk (2 bytes)
+    // 10 - total number of entries in the central directory (2 bytes)
+    let entryCount = readUInt16LE(tail, eocdrOffset + 10);
+    // 12 - size of the central directory (4 bytes)
+    let centralDirectorySize = readUInt32LE(tail, eocdrOffset + 12);
+    // 16 - offset of start of central directory (4 bytes)
+    let centralDirectoryOffset = readUInt32LE(tail, eocdrOffset + 16);
+
+    const needsZip64 =
+      entryCount === 0xffff ||
+      centralDirectorySize === 0xffffffff ||
+      centralDirectoryOffset === 0xffffffff;
+    if (needsZip64) {
+      const zip64 = await this.getZip64EndOfCentralDirectory(tail, eocdrOffset);
+      ({ entryCount, centralDirectorySize, centralDirectoryOffset } = zip64);
+    }
+
+    if (centralDirectorySize > MAX_CENTRAL_DIRECTORY_SIZE) {
+      throw new InvalidFileError(
+        `central directory too large: [${centralDirectorySize}] bytes exceeds [${MAX_CENTRAL_DIRECTORY_SIZE}]`
+      );
+    }
+    if (centralDirectorySize < entryCount * CENTRAL_DIRECTORY_RECORD_FIXED_SIZE) {
+      throw new InvalidFileError(
+        `central directory size [${centralDirectorySize}] too small for [${entryCount}] entries`
+      );
+    }
+
+    return { entryCount, centralDirectorySize, centralDirectoryOffset, zip64: needsZip64 };
+  }
+
+  /**
+   * Follows the ZIP64 end of central directory locator, which sits immediately
+   * before the EOCD record, and reads the ZIP64 EOCD record it points at.
+   */
+  private async getZip64EndOfCentralDirectory(
+    tail: Uint8Array,
+    eocdrOffset: number
+  ): Promise<Omit<EndOfCentralDirectory, 'zip64'>> {
+    const locatorOffset = eocdrOffset - ZIP64_END_OF_CENTRAL_DIRECTORY_LOCATOR_SIZE;
+    if (locatorOffset < 0 || readUInt32LE(tail, locatorOffset) !== ZIP64_EOCDL_SIGNATURE) {
+      throw new InvalidFileError(
+        'end of central directory record requires zip64, but no zip64 locator was found'
+      );
+    }
+    // 8 - relative offset of the zip64 end of central directory record (8 bytes)
+    const zip64EocdrOffset = readUInt64LE(tail, locatorOffset + 8);
+    const record = await this.getChunk(
+      zip64EocdrOffset,
+      zip64EocdrOffset + ZIP64_END_OF_CENTRAL_DIRECTORY_RECORD_SIZE
+    );
+    if (
+      record.length < ZIP64_END_OF_CENTRAL_DIRECTORY_RECORD_SIZE ||
+      readUInt32LE(record, 0) !== ZIP64_EOCDR_SIGNATURE
+    ) {
+      throw new InvalidFileError(
+        `invalid zip64 end of central directory record at [${zip64EocdrOffset}]`
+      );
+    }
+    return {
+      // 32 - total number of entries in the central directory (8 bytes)
+      entryCount: readUInt64LE(record, 32),
+      // 40 - size of the central directory (8 bytes)
+      centralDirectorySize: readUInt64LE(record, 40),
+      // 48 - offset of start of central directory (8 bytes)
+      centralDirectoryOffset: readUInt64LE(record, 48),
+    };
   }
 
   /**
@@ -97,7 +248,7 @@ export class ZipReader {
     const byteStart = cdObj.relativeOffsetOfLocalHeader + cdObj.headerLength;
     if (cdObj.uncompressedSize > manifestMaxSize) {
       throw new InvalidFileError(
-        `manifest file too large: ${(cdObj.uncompressedSize >> 10).toLocaleString()} KiB`
+        `manifest file too large: ${Math.floor(cdObj.uncompressedSize / 1024).toLocaleString()} KiB`
       );
     }
     const byteEnd = byteStart + cdObj.uncompressedSize;
@@ -137,31 +288,70 @@ export class ZipReader {
   }
 
   /**
-   * extracts the CD buffer entries from the end of a zip file.
-   * @param  chunkBuffer The last portion of a zip file
+   * Splits the central directory into its individual records.
+   *
+   * Boundaries come from each record's own declared name, extra field and comment
+   * lengths - not from scanning for the next signature - and exactly `entryCount`
+   * records are read, as declared by the end of central directory record.
+   *
+   * @param cdChunk the central directory, starting at its first record
+   * @param entryCount the number of records the EOCD says are present
    * @returns an array of typed arrays, each element corresponding to a central directory record
    */
-  getCDBuffers(chunkBuffer: Uint8Array): Uint8Array[] {
-    const cdBuffers = [];
-    let lastBufferOffset = chunkBuffer.length;
-    for (let i = chunkBuffer.length - 22; i >= 0; i -= 1) {
-      // If what we're locking at isn't the start of a central directory, skip it..
-      if (readUInt32LE(chunkBuffer, i) !== CD_SIGNATURE) {
-        // eslint-disable-next-line no-continue
-        continue;
+  getCDBuffers(cdChunk: Uint8Array, entryCount: number): Uint8Array[] {
+    const cdBuffers: Uint8Array[] = [];
+    let offset = 0;
+    for (let i = 0; i < entryCount; i++) {
+      if (offset + CENTRAL_DIRECTORY_RECORD_FIXED_SIZE > cdChunk.length) {
+        throw new InvalidFileError(
+          `central directory ended early: found [${i}] of [${entryCount}] declared entries`
+        );
       }
-      // Slice off that CD from it's start until the end of either the buffer, or whatever the start of the previously
-      // found CD was
-      cdBuffers.push(chunkBuffer.slice(i, lastBufferOffset));
-      // Store the last offset location so we know how to slice off hte next CD.
-      lastBufferOffset = i;
-      // We can skip over 22 iterations since we know the minimum size of a CD is 22.
-      i -= 22;
+      if (readUInt32LE(cdChunk, offset) !== CD_SIGNATURE) {
+        throw new InvalidFileError(
+          `invalid central directory file header signature for entry [${i}]`
+        );
+      }
+      // 28 - file name length (n), 30 - extra field length (m), 32 - file comment length (k)
+      const fileNameLength = readUInt16LE(cdChunk, offset + 28);
+      const extraFieldLength = readUInt16LE(cdChunk, offset + 30);
+      const fileCommentLength = readUInt16LE(cdChunk, offset + 32);
+      const recordLength =
+        CENTRAL_DIRECTORY_RECORD_FIXED_SIZE + fileNameLength + extraFieldLength + fileCommentLength;
+      if (offset + recordLength > cdChunk.length) {
+        throw new InvalidFileError(
+          `central directory record [${i}] of length [${recordLength}] overruns the central directory`
+        );
+      }
+      cdBuffers.push(cdChunk.slice(offset, offset + recordLength));
+      offset += recordLength;
     }
-
-    // They should be in the correct order. Since we iterate backwards, it's built backwards.
-    return cdBuffers.reverse();
+    return cdBuffers;
   }
+}
+
+/**
+ * Scans a buffer whose final byte is the final byte of the archive for the end of
+ * central directory record.
+ *
+ * A candidate is only accepted when its declared comment length places the end of
+ * the comment exactly at the end of the archive, which rules out payload bytes that
+ * happen to spell the signature.
+ *
+ * @returns the index of the EOCD signature within `tail`, or -1 if not found
+ */
+function findEndOfCentralDirectoryRecord(tail: Uint8Array): number {
+  for (let i = tail.length - END_OF_CENTRAL_DIRECTORY_RECORD_SIZE; i >= 0; i--) {
+    if (readUInt32LE(tail, i) !== EOCDR_SIGNATURE) {
+      continue;
+    }
+    // 20 - .ZIP file comment length (2 bytes)
+    const commentLength = readUInt16LE(tail, i + 20);
+    if (i + END_OF_CENTRAL_DIRECTORY_RECORD_SIZE + commentLength === tail.length) {
+      return i;
+    }
+  }
+  return -1;
 }
 
 function parseCentralDirectoryWithNoExtras(cdBuffer: Uint8Array): CentralDirectory {
@@ -215,14 +405,21 @@ function parseCentralDirectoryWithNoExtras(cdBuffer: Uint8Array): CentralDirecto
  * @return The CD object
  */
 export function parseCDBuffer(cdBuffer: Uint8Array): CentralDirectory {
+  if (cdBuffer.length < CENTRAL_DIRECTORY_RECORD_FIXED_SIZE) {
+    throw new InvalidFileError('Truncated central directory file header');
+  }
   if (readUInt32LE(cdBuffer, 0) !== CD_SIGNATURE) {
     throw new InvalidFileError('Invalid central directory file header signature');
   }
 
   const cd = parseCentralDirectoryWithNoExtras(cdBuffer);
 
-  if (cd.versionNeededToExtract < VERSION_NEEDED_TO_EXTRACT_ZIP64 || !cd.extraFieldLength) {
-    // NOTE(PLAT-1134) Zip64 was added in pkzip 4.5
+  // NOTE(DSPX-4591): APPNOTE 4.5.3 does not condition the validity of a zip64
+  // extended information extra field on `version needed to extract`; the sentinel
+  // values in the fixed-size fields are what select it. Gating on the version byte
+  // silently dropped the extra field, leaving 0xffffffff to flow into offset and
+  // size arithmetic as if it were a real number.
+  if (!cd.extraFieldLength) {
     return cd;
   }
 

--- a/lib/tdf3/src/utils/zip-writer.ts
+++ b/lib/tdf3/src/utils/zip-writer.ts
@@ -168,7 +168,20 @@ export class ZipWriter {
     ]);
   }
 
-  writeDataDescriptor(crc32: number, uncompressedSize: number): Uint8Array {
+  /**
+   * Builds a data descriptor record (APPNOTE 4.3.9):
+   * `signature, crc-32, compressed size, uncompressed size`.
+   *
+   * @param crc32 CRC-32 of the uncompressed data
+   * @param uncompressedSize size of the entry before compression
+   * @param compressedSize size of the entry as stored; defaults to `uncompressedSize`
+   *   because we only ever use the STORE method
+   */
+  writeDataDescriptor(
+    crc32: number,
+    uncompressedSize: number,
+    compressedSize: number = uncompressedSize
+  ): Uint8Array {
     // NOTE(PLAT-1134): optional signature (required according to Archive Utility)
     // 4.3.9.3 Although not originally assigned a signature, the value
     // 0x08074b50 has commonly been adopted as a signature value
@@ -188,16 +201,15 @@ export class ZipWriter {
       // the file the compressed and uncompressed sizes will be 8
       // byte values.
       buffer = new Uint8Array(ZIP64_DATA_DESCRIPTOR_SIZE);
-      writeUInt32LE(buffer, crc32, 4);
       writeUInt32LE(buffer, ddSig, 0);
-      // We just use STORE, so compressed and uncompressed are the same.
-      writeUInt64LE(buffer, uncompressedSize, 8);
+      writeUInt32LE(buffer, crc32, 4);
+      writeUInt64LE(buffer, compressedSize, 8);
       writeUInt64LE(buffer, uncompressedSize, 16);
     } else {
       buffer = new Uint8Array(DATA_DESCRIPTOR_SIZE);
       writeUInt32LE(buffer, ddSig, 0);
       writeUInt32LE(buffer, crc32, 4);
-      writeUInt32LE(buffer, uncompressedSize, 8);
+      writeUInt32LE(buffer, compressedSize, 8);
       writeUInt32LE(buffer, uncompressedSize, 12);
     }
     return buffer;

--- a/lib/tests/mocha/unit/zip.spec.ts
+++ b/lib/tests/mocha/unit/zip.spec.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 
 import { encodeArrayBuffer } from '../../../src/encodings/base64.js';
+import { fromBuffer } from '../../../src/seekable.js';
 import {
   CentralDirectory,
   parseCDBuffer,
@@ -8,6 +9,137 @@ import {
   ZipReader,
 } from '../../../tdf3/src/utils/zip-reader.js';
 import { ZipWriter, dateToDosDateTime, writeUInt64LE } from '../../../tdf3/src/utils/zip-writer.js';
+
+const CD_SIGNATURE_BYTES = new Uint8Array([0x50, 0x4b, 0x01, 0x02]);
+const EOCD_SIGNATURE_BYTES = new Uint8Array([0x50, 0x4b, 0x05, 0x06]);
+const DATA_DESCRIPTOR_SIZE = 16;
+const ZIP64_DATA_DESCRIPTOR_SIZE = 24;
+const FIXED_DATE = new Date('1980-01-01T00:00:00');
+
+function concat(chunks: Uint8Array[]): Uint8Array {
+  const out = new Uint8Array(chunks.reduce((n, c) => n + c.length, 0));
+  let at = 0;
+  for (const c of chunks) {
+    out.set(c, at);
+    at += c.length;
+  }
+  return out;
+}
+
+function u16(buf: Uint8Array, offset: number): number {
+  return buf[offset] | (buf[offset + 1] << 8);
+}
+
+function setU16(buf: Uint8Array, offset: number, value: number): void {
+  buf[offset] = value & 0xff;
+  buf[offset + 1] = (value >> 8) & 0xff;
+}
+
+type ZipEntry = { name: string; data: Uint8Array };
+
+type BuildZipOptions = {
+  zip64?: boolean;
+  /** Trailing .ZIP file comment, appended after the end of central directory record. */
+  comment?: Uint8Array;
+  /** Rewrites each central directory record before it is appended. */
+  mapCentralDirectoryRecord?: (record: Uint8Array, index: number) => Uint8Array;
+};
+
+/**
+ * Assembles a complete, well formed zip archive in memory so the reader can be
+ * exercised end to end rather than against hand-rolled record fragments.
+ */
+function buildZip(entries: ZipEntry[], options: BuildZipOptions = {}): Uint8Array {
+  const { zip64 = true, comment, mapCentralDirectoryRecord } = options;
+  const zipWriter = new ZipWriter();
+  zipWriter.zip64 = zip64;
+  const descriptorSize = zip64 ? ZIP64_DATA_DESCRIPTOR_SIZE : DATA_DESCRIPTOR_SIZE;
+
+  const body: Uint8Array[] = [];
+  const centralDirectory: Uint8Array[] = [];
+  let offset = 0;
+  entries.forEach(({ name, data }, index) => {
+    const crc32 = 0;
+    const localFileHeader = zipWriter.getLocalFileHeader(
+      name,
+      crc32,
+      data.length,
+      data.length,
+      FIXED_DATE
+    );
+    body.push(localFileHeader, data, zipWriter.writeDataDescriptor(crc32, data.length));
+    let record = zipWriter.writeCentralDirectoryRecord(
+      data.length,
+      name,
+      offset,
+      crc32,
+      0x81a40000,
+      FIXED_DATE
+    );
+    if (mapCentralDirectoryRecord) {
+      record = mapCentralDirectoryRecord(record, index);
+    }
+    centralDirectory.push(record);
+    offset += localFileHeader.length + data.length + descriptorSize;
+  });
+
+  const cdBuffer = concat(centralDirectory);
+  const eocdBuffer = zipWriter.writeEndOfCentralDirectoryRecord(
+    entries.length,
+    cdBuffer.length,
+    offset
+  );
+  if (!comment?.length) {
+    return concat([...body, cdBuffer, eocdBuffer]);
+  }
+  // The end of central directory record is always the final 22 bytes of what the
+  // writer returns; patch its comment length and append the comment itself.
+  setU16(eocdBuffer, eocdBuffer.length - 2, comment.length);
+  return concat([...body, cdBuffer, eocdBuffer, comment]);
+}
+
+/**
+ * Inserts an extra field ahead of whatever extra fields a central directory record
+ * already carries, so the ZIP64 extra field is no longer the first one.
+ */
+function prependExtraField(record: Uint8Array, headerId: number, data: Uint8Array): Uint8Array {
+  const fileNameLength = u16(record, 28);
+  const extraFieldLength = u16(record, 30);
+  const extraStart = 46 + fileNameLength;
+
+  const inserted = new Uint8Array(4 + data.length);
+  setU16(inserted, 0, headerId);
+  setU16(inserted, 2, data.length);
+  inserted.set(data, 4);
+
+  const head = record.slice(0, extraStart);
+  setU16(head, 30, extraFieldLength + inserted.length);
+  return concat([head, inserted, record.slice(extraStart)]);
+}
+
+/**
+ * The pre-DSPX-4591 reader: scan the tail of the file backwards and treat every
+ * central directory signature as the start of an entry. Kept here only to
+ * demonstrate that the archives below actually defeat it.
+ */
+function legacyCentralDirectoryScan(chunkBuffer: Uint8Array): number {
+  let found = 0;
+  for (let i = chunkBuffer.length - 22; i >= 0; i -= 1) {
+    if (
+      chunkBuffer[i] !== 0x50 ||
+      chunkBuffer[i + 1] !== 0x4b ||
+      chunkBuffer[i + 2] !== 0x01 ||
+      chunkBuffer[i + 3] !== 0x02
+    ) {
+      continue;
+    }
+    found += 1;
+    i -= 22;
+  }
+  return found;
+}
+
+const manifestBytes = (manifest: unknown) => new TextEncoder().encode(JSON.stringify(manifest));
 
 describe('zip utilities', () => {
   describe('dateToDos', () => {
@@ -101,6 +233,39 @@ describe('zip utilities', () => {
       expect(encodeArrayBuffer(descriptorBuffer.buffer)).to.equal(
         'UEsHCDcTAAD0AQAAAAAAAPQBAAAAAAAA'
       );
+    });
+    // DSPX-4591 finding 3: the record is `signature, crc-32, compressed size,
+    // uncompressed size`. The non-zip64 branch used to write the uncompressed size
+    // into both slots, which only looked right because we always STORE.
+    it('standard, distinct compressed size', async () => {
+      const zipWriter = new ZipWriter();
+      zipWriter.zip64 = false;
+      const descriptorBuffer = zipWriter.writeDataDescriptor(0x1337, 500, 321);
+      const view = new DataView(
+        descriptorBuffer.buffer,
+        descriptorBuffer.byteOffset,
+        descriptorBuffer.byteLength
+      );
+      expect(descriptorBuffer.length).to.equal(DATA_DESCRIPTOR_SIZE);
+      expect(view.getUint32(0, true)).to.equal(0x08074b50);
+      expect(view.getUint32(4, true)).to.equal(0x1337);
+      expect(view.getUint32(8, true)).to.equal(321);
+      expect(view.getUint32(12, true)).to.equal(500);
+    });
+    it('zip64, distinct compressed size', async () => {
+      const zipWriter = new ZipWriter();
+      zipWriter.zip64 = true;
+      const descriptorBuffer = zipWriter.writeDataDescriptor(0x1337, 500, 321);
+      const view = new DataView(
+        descriptorBuffer.buffer,
+        descriptorBuffer.byteOffset,
+        descriptorBuffer.byteLength
+      );
+      expect(descriptorBuffer.length).to.equal(ZIP64_DATA_DESCRIPTOR_SIZE);
+      expect(view.getUint32(0, true)).to.equal(0x08074b50);
+      expect(view.getUint32(4, true)).to.equal(0x1337);
+      expect(view.getBigUint64(8, true)).to.equal(321n);
+      expect(view.getBigUint64(16, true)).to.equal(500n);
     });
   });
 
@@ -198,5 +363,267 @@ describe('reader', () => {
     } catch (e) {
       expect(e.message).to.contain('too large');
     }
+  });
+
+  // DSPX-4591 finding 4: `>>` coerces to signed 32 bits, so 2 GiB used to be
+  // reported as a negative number of KiB.
+  it('reports oversized manifests without 32 bit wraparound', async () => {
+    const reader = new ZipReader(async () => new Uint8Array([]));
+    const fileName = '0.manifest.json';
+    let message = '';
+    try {
+      await reader.getManifest(
+        [
+          {
+            fileName,
+            relativeOffsetOfLocalHeader: 0,
+            headerLength: 1024,
+            uncompressedSize: 2 ** 31,
+          } as CentralDirectory,
+        ],
+        fileName
+      );
+      expect.fail('expected an oversized manifest to be rejected');
+    } catch (e) {
+      message = e.message;
+    }
+    expect(message).to.contain('too large');
+    expect(message).to.not.contain('-');
+    expect(message).to.contain((2 ** 21).toLocaleString());
+  });
+
+  describe('getCentralDirectory', () => {
+    const manifest = { payload: { type: 'reference' } };
+
+    it('reads a zip64 archive written by ZipWriter', async () => {
+      const zipFile = buildZip([
+        { name: '0.manifest.json', data: manifestBytes(manifest) },
+        { name: '0.payload', data: new Uint8Array([1, 2, 3, 4, 5]) },
+      ]);
+      const reader = new ZipReader(fromBuffer(zipFile));
+      const centralDirectory = await reader.getCentralDirectory();
+      expect(centralDirectory.map(({ fileName }) => fileName)).to.eql([
+        '0.manifest.json',
+        '0.payload',
+      ]);
+      expect(await reader.getManifest(centralDirectory, '0.manifest.json')).to.eql(manifest);
+      expect(await reader.getPayloadSegment(centralDirectory, '0.payload', 0, 5)).to.eql(
+        new Uint8Array([1, 2, 3, 4, 5])
+      );
+    });
+
+    it('reads a non-zip64 archive', async () => {
+      const zipFile = buildZip(
+        [
+          { name: '0.manifest.json', data: manifestBytes(manifest) },
+          { name: '0.payload', data: new Uint8Array([9, 8, 7]) },
+        ],
+        { zip64: false }
+      );
+      const reader = new ZipReader(fromBuffer(zipFile));
+      const centralDirectory = await reader.getCentralDirectory();
+      expect(centralDirectory.map(({ fileName }) => fileName)).to.eql([
+        '0.manifest.json',
+        '0.payload',
+      ]);
+      expect(await reader.getManifest(centralDirectory, '0.manifest.json')).to.eql(manifest);
+    });
+
+    // DSPX-4591 finding 1: the EOCD is not necessarily the last bytes of the file.
+    it('reads an archive with a trailing comment', async () => {
+      const comment = new TextEncoder().encode('a comment that follows the EOCD record');
+      const zipFile = buildZip(
+        [
+          { name: '0.manifest.json', data: manifestBytes(manifest) },
+          { name: '0.payload', data: new Uint8Array([1, 2, 3]) },
+        ],
+        { comment }
+      );
+      const reader = new ZipReader(fromBuffer(zipFile));
+      const centralDirectory = await reader.getCentralDirectory();
+      expect(centralDirectory.map(({ fileName }) => fileName)).to.eql([
+        '0.manifest.json',
+        '0.payload',
+      ]);
+      expect(await reader.getManifest(centralDirectory, '0.manifest.json')).to.eql(manifest);
+    });
+
+    it('reads an archive whose comment contains an EOCD signature', async () => {
+      const comment = concat([
+        new TextEncoder().encode('trailing '),
+        EOCD_SIGNATURE_BYTES,
+        new TextEncoder().encode(' bytes'),
+      ]);
+      const zipFile = buildZip([{ name: '0.manifest.json', data: manifestBytes(manifest) }], {
+        comment,
+      });
+      const reader = new ZipReader(fromBuffer(zipFile));
+      const centralDirectory = await reader.getCentralDirectory();
+      expect(centralDirectory).to.have.length(1);
+      expect(await reader.getManifest(centralDirectory, '0.manifest.json')).to.eql(manifest);
+    });
+
+    it('reads an archive with a maximum length comment', async () => {
+      const comment = new Uint8Array(0xffff).fill(0x2e);
+      const zipFile = buildZip([{ name: '0.manifest.json', data: manifestBytes(manifest) }], {
+        comment,
+      });
+      const reader = new ZipReader(fromBuffer(zipFile));
+      const centralDirectory = await reader.getCentralDirectory();
+      expect(centralDirectory.map(({ fileName }) => fileName)).to.eql(['0.manifest.json']);
+    });
+
+    // DSPX-4591 finding 1, the false positive case. A payload that happens to
+    // contain 0x02014b50 defeated the backward signature scan.
+    it('ignores central directory signatures inside the payload', async () => {
+      const payload = concat([
+        new Uint8Array([0xde, 0xad]),
+        CD_SIGNATURE_BYTES,
+        new Uint8Array(64).fill(0x00),
+        CD_SIGNATURE_BYTES,
+        new Uint8Array([0xbe, 0xef]),
+      ]);
+      const zipFile = buildZip([
+        { name: '0.manifest.json', data: manifestBytes(manifest) },
+        { name: '0.payload', data: payload },
+      ]);
+
+      // Precondition: the old backward scan really does see more than two entries.
+      expect(legacyCentralDirectoryScan(zipFile)).to.be.greaterThan(2);
+
+      const reader = new ZipReader(fromBuffer(zipFile));
+      const centralDirectory = await reader.getCentralDirectory();
+      expect(centralDirectory.map(({ fileName }) => fileName)).to.eql([
+        '0.manifest.json',
+        '0.payload',
+      ]);
+      expect(await reader.getManifest(centralDirectory, '0.manifest.json')).to.eql(manifest);
+      expect(
+        await reader.getPayloadSegment(centralDirectory, '0.payload', 0, payload.length)
+      ).to.eql(payload);
+    });
+
+    it('rejects an archive with no end of central directory record', async () => {
+      const zipFile = buildZip([{ name: '0.manifest.json', data: manifestBytes(manifest) }]);
+      // Drop the EOCD record (and any zip64 trailer) entirely.
+      const truncated = zipFile.slice(0, zipFile.length - 98);
+      const reader = new ZipReader(fromBuffer(truncated));
+      let message = '';
+      try {
+        await reader.getCentralDirectory();
+        expect.fail('expected a missing EOCD to be rejected');
+      } catch (e) {
+        message = e.message;
+      }
+      expect(message).to.contain('end of central directory');
+    });
+
+    it('rejects a zip64 archive whose locator is missing', async () => {
+      const zipFile = buildZip([{ name: '0.manifest.json', data: manifestBytes(manifest) }]);
+      // Corrupt the zip64 end of central directory locator signature.
+      zipFile[zipFile.length - 22 - 20] ^= 0xff;
+      const reader = new ZipReader(fromBuffer(zipFile));
+      let message = '';
+      try {
+        await reader.getCentralDirectory();
+        expect.fail('expected a missing zip64 locator to be rejected');
+      } catch (e) {
+        message = e.message;
+      }
+      expect(message).to.contain('zip64 locator');
+    });
+
+    it('rejects an end of central directory record that overstates the entry count', async () => {
+      const zipFile = buildZip(
+        [
+          { name: '0.manifest.json', data: manifestBytes(manifest) },
+          { name: '0.payload', data: new Uint8Array([1, 2, 3]) },
+        ],
+        { zip64: false }
+      );
+      // 22 byte EOCD at the end: entry counts live at offsets 8 and 10.
+      const eocdStart = zipFile.length - 22;
+      setU16(zipFile, eocdStart + 8, 3);
+      setU16(zipFile, eocdStart + 10, 3);
+      const reader = new ZipReader(fromBuffer(zipFile));
+      let message = '';
+      try {
+        await reader.getCentralDirectory();
+        expect.fail('expected a bad entry count to be rejected');
+      } catch (e) {
+        message = e.message;
+      }
+      expect(message).to.contain('central directory');
+    });
+  });
+
+  // DSPX-4591 finding 2: the zip64 extra field is selected by the sentinel values,
+  // not by its position in the extra field area nor by versionNeededToExtract.
+  describe('zip64 extended information extra field', () => {
+    it('is honoured when it is not the first extra field', () => {
+      const zipWriter = new ZipWriter();
+      zipWriter.zip64 = true;
+      const record = prependExtraField(
+        zipWriter.writeCentralDirectoryRecord(
+          2 ** 50,
+          'Hey.txt',
+          2000,
+          0x1337,
+          0x81a40000,
+          FIXED_DATE
+        ),
+        // 0x5455 is the "extended timestamp" field; any non-zip64 field will do.
+        0x5455,
+        new Uint8Array([0x01, 0x00, 0x00, 0x00, 0x00])
+      );
+      expect(parseCDBuffer(record)).to.deep.include({
+        compressedSize: 2 ** 50,
+        uncompressedSize: 2 ** 50,
+        relativeOffsetOfLocalHeader: 2000,
+        fileName: 'Hey.txt',
+      });
+    });
+
+    it('is honoured in a full archive when it is not the first extra field', async () => {
+      const manifest = { payload: { type: 'reference' } };
+      const zipFile = buildZip(
+        [
+          { name: '0.manifest.json', data: manifestBytes(manifest) },
+          { name: '0.payload', data: new Uint8Array([4, 5, 6]) },
+        ],
+        {
+          mapCentralDirectoryRecord: (record) =>
+            prependExtraField(record, 0x5455, new Uint8Array([0x01, 0x00, 0x00, 0x00, 0x00])),
+        }
+      );
+      const reader = new ZipReader(fromBuffer(zipFile));
+      const centralDirectory = await reader.getCentralDirectory();
+      expect(centralDirectory.map(({ fileName }) => fileName)).to.eql([
+        '0.manifest.json',
+        '0.payload',
+      ]);
+      expect(await reader.getManifest(centralDirectory, '0.manifest.json')).to.eql(manifest);
+    });
+
+    it('is honoured when versionNeededToExtract is below 45', () => {
+      const zipWriter = new ZipWriter();
+      zipWriter.zip64 = true;
+      const record = zipWriter.writeCentralDirectoryRecord(
+        2 ** 50,
+        'Hey.txt',
+        2000,
+        0x1337,
+        0x81a40000,
+        FIXED_DATE
+      );
+      // 6 - version needed to extract. Claim 2.0, keep the zip64 extra field.
+      setU16(record, 6, 20);
+      expect(parseCDBuffer(record)).to.deep.include({
+        versionNeededToExtract: 20,
+        compressedSize: 2 ** 50,
+        uncompressedSize: 2 ** 50,
+        relativeOffsetOfLocalHeader: 2000,
+      });
+    });
   });
 });

--- a/spec/DSPX-4591.md
+++ b/spec/DSPX-4591.md
@@ -1,0 +1,121 @@
+# DSPX-4591 — zip64 conformance issues: web-sdk
+
+> Copy of the Jira ticket (https://virtru.atlassian.net/browse/DSPX-4591) as of
+> 2026-09-03. Siblings: DSPX-4589 (java-sdk), DSPX-4590 (go-sdk),
+> DSPX-4592 (xtest interop harness — **already done**, see "Harness status" at
+> the bottom).
+
+## Background
+
+A TDF3 container is a ZIP archive, and each SDK carries its own hand-rolled ZIP reader/writer rather than using a stock library. Auditing [java-sdk PR #393](https://github.com/opentdf/java-sdk/pull/393) against the Go and Web implementations turned up a set of ZIP64/APPNOTE conformance divergences. Sibling tickets cover java-sdk and go-sdk.
+
+Reference: PKWARE APPNOTE.TXT, section 4.5.3 (ZIP64 Extended Information Extra Field).
+
+Code lives in `opentdf/web-sdk`: `lib/tdf3/src/utils/zip-writer.ts` and `lib/tdf3/src/utils/zip-reader.ts`. Line numbers are against `main` at time of filing.
+
+### Cross-SDK writer posture
+
+| SDK | ZIP64 switch point for offsets/sizes |
+| --- | --- |
+| java-sdk (after #393) | 2 GiB (`Integer.MAX_VALUE`) |
+| go-sdk | 4 GiB (`0xFFFFFFFF`) — being moved to 2 GiB |
+| web-sdk | always ZIP64 — **already safe, no change needed** |
+
+`ZipWriter` sets `this.zip64 = true` in its constructor (`zip-writer.ts:102-106`) and never clears it, so web-sdk unconditionally emits ZIP64 structures. That is the safest posture and web-sdk needs no threshold change. The findings below are separate.
+
+## Findings
+
+### 1. Reader never parses the end-of-central-directory record
+
+`zip-reader.ts:140-165`, `getCDBuffers()`. Rather than reading the EOCD (and, when sentinelled, the ZIP64 EOCD locator and ZIP64 EOCD record) to learn where the central directory starts and how many entries it has, the reader scans a trailing chunk **backwards byte by byte** looking for anything matching the central-directory signature `0x02014b50`, and treats each hit as a CD entry.
+
+This is a heuristic standing in for the format's actual index. Consequences:
+
+* A payload byte sequence that happens to equal `0x02014b50` inside the scanned tail is accepted as a central directory record, and the resulting garbage entry participates in the returned list.
+* Entry boundaries are inferred from the position of the _next_ match rather than from the declared filename/extra/comment lengths, so a malformed or hostile archive can steer parsing.
+* There is no cross-check that the number of records found equals the EOCD's declared entry count, and no validation that the CD starts where the EOCD says it does.
+
+**Fix:** locate and parse the EOCD properly, follow the ZIP64 locator when any of the three EOCD fields carries its sentinel (entry count `0xFFFF`, CD size `0xFFFFFFFF`, CD offset `0xFFFFFFFF`), then walk exactly the declared number of entries from the declared CD offset, advancing by `46 + fileNameLength + extraFieldLength + fileCommentLength` each time. Keep the backward scan only as a fallback for archives with trailing comments, if at all.
+
+### 2. ZIP64 extra field is ignored unless `versionNeededToExtract >= 45`
+
+`zip-reader.ts:224`:
+
+```ts
+if (cd.versionNeededToExtract < VERSION_NEEDED_TO_EXTRACT_ZIP64 || !cd.extraFieldLength) {
+  return cd;
+}
+```
+
+APPNOTE does not condition the validity of a ZIP64 extended information extra field on the version-needed-to-extract byte. A conformant producer that writes a ZIP64 extra field while declaring a lower version — or one that writes ZIP64 extras opportunistically per entry — has its extra field silently dropped, leaving `uncompressedSize` / `relativeOffsetOfLocalHeader` at `0xFFFFFFFF`. That then flows into `byteStart`/`byteEnd` arithmetic as a real number, producing a nonsensical range request rather than an error.
+
+Both our other SDKs write version `0x2D` (45), so this does not currently bite in cross-SDK use. Fix is to drop the version gate and key purely off the sentinel values, which the surrounding code already does correctly.
+
+**Credit where due:** the rest of this function is the best of the three implementations — `sliceExtraFields` (`zip-reader.ts:316-339`) properly iterates the whole extra-field area, rejects conflicting duplicate header IDs, bounds-checks `dataSize` against the buffer, and reads the ZIP64 fields in correct APPNOTE 4.5.3 order (uncompressed, compressed, offset) with explicit length checks. go-sdk should copy this shape.
+
+### 3. Non-ZIP64 data descriptor writes `uncompressedSize` twice
+
+`zip-writer.ts:196-201`:
+
+```ts
+writeUInt32LE(buffer, ddSig, 0);
+writeUInt32LE(buffer, crc32, 4);
+writeUInt32LE(buffer, uncompressedSize, 8);   // should be compressedSize
+writeUInt32LE(buffer, uncompressedSize, 12);
+```
+
+The data descriptor is `signature, crc32, compressedSize, uncompressedSize`. The compressed size slot is populated with the uncompressed size. This is dead code today — `this.zip64` is hardcoded `true`, so the non-ZIP64 branch is never taken, and for STORED entries the two values are equal anyway — but it is wrong and it will bite whoever makes the ZIP64 flag conditional.
+
+**Fix:** write `compressedSize` at offset 8. Either that, or delete the non-ZIP64 branch outright given the constructor hardcodes the flag; if we keep the branch, it needs a test.
+
+### 4. 32-bit shift on a potentially large size in an error path
+
+`zip-reader.ts:98-101`:
+
+```ts
+`manifest file too large: ${(cdObj.uncompressedSize >> 10).toLocaleString()} KiB`
+```
+
+`>>` coerces to a signed 32-bit integer in JS, so any size at or above 2 GiB reports a negative or wrapped figure. Error-message-only, and a 2 GiB manifest is not a real scenario, but `Math.floor(x / 1024)` is the correct operation and costs nothing.
+
+## Acceptance criteria
+
+* Reader locates and parses the EOCD (and ZIP64 EOCD via the locator) instead of signature-scanning; entry count and CD offset are taken from the record and validated.
+* ZIP64 extra field is honoured based on sentinel values, independent of `versionNeededToExtract`.
+* Data descriptor writes compressed size in the compressed size slot, or the dead branch is removed.
+* Size-to-KiB conversion uses division, not `>>`.
+* Tests in `lib/tests/mocha/unit/zip.spec.ts` extended to cover: an archive with a comment, an entry whose ZIP64 extra is not the first extra field, and a payload containing the bytes `0x02014b50` (the false-positive case for the current scanner).
+* Cross-SDK interop coverage added - see below.
+
+## Shared cross-SDK work
+
+The three tickets should converge on a common interop check in `opentdf/tests` (xtest): generate a TDF whose payload lands in the 2-4 GiB band in each SDK, and decrypt it with all three. This is the case none of the per-repo unit tests can cover, and it is the one that actually breaks in the field. Coordinate so it is only built once - whichever ticket gets there first owns it.
+
+_Filed from an audit of java-sdk PR #393. The IV/counter and_ `MAX_TDF_INPUT_SIZE` portions of that PR are a separate concern and are not in scope here.
+
+---
+
+## Harness status (DSPX-4592 — already built, do not rebuild)
+
+The "shared cross-SDK work" item above is **done**. It lives in `opentdf/tests`
+on branch `DSPX-4592-java-underflow`. Nothing in this ticket requires touching
+that repo, and you should not: DSPX-4592 owns it.
+
+## Note on the segment-size defect (context, not scope)
+
+The harness turned up a separate cross-SDK bug that is worth understanding
+before touching this reader, because it is easy to "fix" in the wrong repo.
+
+`lib/tdf3/src/tdf.ts:696-700` omits `segmentSize` / `encryptedSegmentSize` from
+a segment object whenever they equal the manifest-level defaults. **This is
+legal and web-sdk is not at fault** — `manifest.schema.json` gives
+`segments/items` no `required` list, and web-sdk's own reader defaults them back
+(`segmentSize = segmentSizeDefault` destructuring). go-sdk and java-sdk fail to
+apply that fallback, which is why every web-sdk TDF over 1 MiB is currently
+unreadable by them. Those are DSPX-4590 finding 7 and DSPX-4589 finding 4
+respectively.
+
+**Do not change web-sdk's emission behaviour to work around it.** Making
+web-sdk write the redundant fields would paper over two real reader bugs and
+silently un-cover them. If you believe there is a reason to change it anyway,
+raise it rather than doing it in this PR.


### PR DESCRIPTION
https://virtru.atlassian.net/browse/DSPX-4591

Audit of [java-sdk #393](https://github.com/opentdf/java-sdk/pull/393) against the Go
and Web zip implementations turned up four ZIP64/APPNOTE conformance divergences in
web-sdk. All four are addressed here.

Note on the writer's ZIP64 threshold: there isn't one, and that's deliberate.
`ZipWriter` sets `this.zip64 = true` in its constructor and never clears it, so
web-sdk unconditionally emits ZIP64 structures. That is already the safest posture
and is unchanged by this PR. The siblings (DSPX-4589 java-sdk, DSPX-4590 go-sdk) are
the ones moving thresholds.

## Finding 1 — the reader never parsed the end of central directory record

`getCDBuffers()` scanned the last 1000 bytes of the file backwards for anything
matching the central directory signature `0x02014b50` and treated every hit as an
entry, inferring record boundaries from the position of the *next* hit.

Replaced with real end-of-central-directory parsing:

* `ZipReader.getEndOfCentralDirectory()` locates the EOCD record by scanning the tail
  for `0x06054b50` and accepting a candidate only when its declared comment length
  puts the end of the comment exactly at the end of the archive. That rules out
  payload bytes that happen to spell the signature, and it handles trailing archive
  comments. The tail read starts at 1 KiB (enough for the comment-less containers we
  write) and widens once to `22 + 0xffff + 20` bytes if the record isn't in there.
* When any of the three EOCD fields carries its sentinel (`0xffff` entry count,
  `0xffffffff` CD size, `0xffffffff` CD offset) the reader follows the ZIP64 end of
  central directory locator that sits immediately before the EOCD and reads the ZIP64
  EOCD record it points at, taking the entry count, CD size and CD offset from there.
* `getCDBuffers()` now takes the central directory chunk plus the declared entry
  count, and walks *exactly* that many records from the declared offset, advancing by
  `46 + fileNameLength + extraFieldLength + fileCommentLength` and validating the
  signature and the remaining length at each step.
* Cross-checks added: the CD chunk must be the declared length, the declared CD size
  must be at least `46 * entryCount`, and it is bounded at 16 MiB so a hostile or
  corrupt EOCD can't ask us to buffer the sentinel 4 GiB.

`getCDBuffers` changed signature. It's a public method on `ZipReader` but `ZipReader`
is not re-exported from any package entry point (`lib/tdf3/src/utils/index.ts` only),
so this isn't a published API break.

## Finding 2 — ZIP64 extra field ignored unless `versionNeededToExtract >= 45`

Dropped the version gate in `parseCDBuffer`. APPNOTE 4.5.3 does not condition the
validity of a ZIP64 extended information extra field on the version-needed-to-extract
byte; the sentinel values in the fixed-size fields are what select it. The gate meant
a conformant producer writing a ZIP64 extra with a lower declared version had it
silently dropped, leaving `0xffffffff` to flow into `byteStart`/`byteEnd` arithmetic
as if it were a real number.

`sliceExtraFields` already did the right thing (iterates the whole extra-field area,
rejects conflicting duplicate header IDs, bounds-checks `dataSize`, reads the ZIP64
fields in APPNOTE order) and is unchanged. Also added a length guard to `parseCDBuffer`
so a record shorter than the 46-byte fixed prefix is rejected rather than parsed out
of a short buffer.

## Finding 3 — non-ZIP64 data descriptor wrote `uncompressedSize` twice

Kept the branch and fixed it, rather than deleting it. Justification: `ZipWriter.zip64`
is a public mutable field and the existing unit tests exercise `zip64 = false` for all
four writer methods (`getLocalFileHeader`, `writeDataDescriptor`,
`writeCentralDirectoryRecord`, `writeEndOfCentralDirectoryRecord`). Deleting one of
those four branches would leave the writer unable to emit a coherent non-ZIP64 archive
while the other three remain, which is a worse state than the bug.

`writeDataDescriptor` now takes an explicit optional `compressedSize` (defaulting to
`uncompressedSize`, since we only ever STORE) and writes it into the compressed size
slot in both the ZIP64 and non-ZIP64 branches. Output for every existing call site is
byte-identical; the existing characteristic tests are unchanged. Two new tests pass
distinct compressed and uncompressed sizes and assert each lands in its own slot.

## Finding 4 — 32-bit shift on a potentially large size in an error path

`(cdObj.uncompressedSize >> 10)` became `Math.floor(cdObj.uncompressedSize / 1024)`.
`>>` coerces to signed 32 bits, so a 2 GiB manifest used to be reported as
`-2,097,152 KiB`. Error-message only.

## Tests

`lib/tests/mocha/unit/zip.spec.ts` gains a `buildZip` helper that assembles complete
in-memory archives with `ZipWriter`, so the reader is exercised end to end rather than
against hand-rolled record fragments. New coverage:

* zip64 and non-zip64 round trips (central directory, manifest, payload segment)
* an archive with a trailing comment
* an archive whose comment contains the EOCD signature bytes
* an archive with a maximum-length (64 KiB) comment, which forces the widened tail read
* **a payload containing the bytes `0x02014b50`** — the false-positive case
* an entry whose ZIP64 extra field is not the first extra field (both as a bare
  central directory record and inside a full archive)
* a ZIP64 extra field honoured with `versionNeededToExtract` forced to 20
* rejection cases: missing EOCD, missing ZIP64 locator, overstated entry count
* the oversized-manifest error message reports a positive KiB figure

The `0x02014b50` test was verified against the pre-change reader: with the old backward
scanner restored, `getCentralDirectory()` returns four entries
(`['', '', '0.manifest.json', '0.payload']`) instead of two, the two empty-named ones
being payload bytes misread as central directory records. It passes with the new
reader.

## Deliberately not changed: segment-size emission

`lib/tdf3/src/tdf.ts` omits `segmentSize` / `encryptedSegmentSize` from a segment
object when they equal the manifest-level defaults, and that stays as it is. The
emission is legal: `manifest.schema.json` gives `segments/items` no `required` list,
and web-sdk's own reader defaults them back. go-sdk and java-sdk fail to apply that
fallback, which is why web-sdk TDFs over 1 MiB are currently unreadable by them —
those are the bugs, tracked as DSPX-4590 finding 7 and DSPX-4589 finding 4. Making
web-sdk write the redundant fields would paper over two real reader bugs and silently
un-cover them.

## Cross-SDK interop

The shared interop harness is DSPX-4592 and is already built in `opentdf/tests` on
branch `DSPX-4592-java-underflow`. It needs nothing from this PR.
